### PR TITLE
Fix package.json commas

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "purge:css": "purgecss --config purgecss.config.js --output ./clean-css"
-  }
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -16,5 +16,5 @@
   },
   "devDependencies": {
     "purgecss": "^7.0.2"
-  },
+  }
 }


### PR DESCRIPTION
## Summary
- correct syntax errors in `package.json`
- add newline at EOF

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('package.json'))"`

------
https://chatgpt.com/codex/tasks/task_e_6863022b0ae8832795d1cc838945d081