### PR TITLE
Refactor makeIconBtn into helpers

### DIFF
--- a/js/daily.js
+++ b/js/daily.js
@@ -1,4 +1,4 @@
-import { loadDecisions, saveDecisions, generateId } from './helpers.js';
+import { loadDecisions, saveDecisions, generateId, makeIconBtn } from './helpers.js';
 
 // Shared skip intervals (same as goals)
 const skipOptions = [
@@ -378,20 +378,6 @@ export async function renderDailyTasks(currentUser, db) {
     row.append(cb, label, btns);
     wrapper.appendChild(row);
     return wrapper;
-  }
-
-  function makeIconBtn(symbol, title, fn) {
-    const b = document.createElement('button');
-    b.type = 'button';
-    b.textContent = symbol;
-    b.title = title;
-    Object.assign(b.style, {
-      background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.1em', padding: '0'
-    });
-    b.addEventListener('mousedown', e => e.stopPropagation());
-    b.addEventListener('click', e => e.stopPropagation());
-    b.onclick = fn;
-    return b;
   }
 
   async function persistReorder() {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -114,5 +114,24 @@ export async function saveLists(lists) {
           .set({ lists: sanitized }, { merge: true });
 }
 
+// Reusable icon-style button factory
+export function makeIconBtn(symbol, title, fn) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.textContent = symbol;
+  b.title = title;
+  Object.assign(b.style, {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '1.1em',
+    padding: '0'
+  });
+  b.addEventListener('mousedown', e => e.stopPropagation());
+  b.addEventListener('click', e => e.stopPropagation());
+  b.onclick = fn;
+  return b;
+}
+
 
 

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -1,27 +1,8 @@
 // ── tasks.js ──
 
-import { loadDecisions, saveDecisions, generateId } from './helpers.js';
+import { loadDecisions, saveDecisions, generateId, makeIconBtn } from './helpers.js';
 import { enableTaskDragAndDrop } from './dragAndDrop.js';
 import { createGoalRow } from './goals.js';
-
-// Reusable icon-style button factory
-function makeIconBtn(symbol, title, fn) {
-    const b = document.createElement('button');
-    b.type = 'button';
-    b.textContent = symbol;
-    b.title = title;
-    Object.assign(b.style, {
-        background: 'none',
-        border: 'none',
-        cursor: 'pointer',
-        fontSize: '1.1em',
-        padding: '0'
-    });
-    b.addEventListener('mousedown', e => e.stopPropagation());
-    b.addEventListener('click', e => e.stopPropagation());
-    b.onclick = fn;
-    return b;
-}
 
 /**
  * Attach ↑, ✏️, 🕒, ❌ buttons to a task-row.


### PR DESCRIPTION
## Summary
- move `makeIconBtn` helper into `helpers.js`
- reuse helper in `tasks.js` and `daily.js`
- remove duplicated function definitions

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686302107a248327a05b62e3db965a1b