### PR TITLE
Batch decision saves

### DIFF
--- a/js/daily.js
+++ b/js/daily.js
@@ -1,4 +1,4 @@
-import { loadDecisions, saveDecisions, generateId } from './helpers.js';
+import { loadDecisions, queueSaveDecisions as saveDecisions, generateId } from './helpers.js';
 
 // Shared skip intervals (same as goals)
 const skipOptions = [

--- a/js/dragAndDrop.js
+++ b/js/dragAndDrop.js
@@ -1,5 +1,5 @@
 
-import { saveGoalOrder, loadDecisions, saveDecisions } from './helpers.js';
+import { saveGoalOrder, loadDecisions, queueSaveDecisions as saveDecisions } from './helpers.js';
 
 let dragSrcEl = null;
 

--- a/js/goalTags.js
+++ b/js/goalTags.js
@@ -1,4 +1,4 @@
-import { loadDecisions, saveDecisions } from './helpers.js';
+import { loadDecisions, queueSaveDecisions as saveDecisions } from './helpers.js';
 
 /* ============================
    Full Function Implementation

--- a/js/goals.js
+++ b/js/goals.js
@@ -5,7 +5,7 @@ import {
 
 import {
     loadDecisions,
-    saveDecisions,
+    queueSaveDecisions as saveDecisions,
     saveGoalOrder
 } from './helpers.js';
 

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -125,5 +125,25 @@ export async function saveLists(lists) {
           .set({ lists: sanitized }, { merge: true });
 }
 
+// ── helper: debounce async functions ────────────────────────────────
+export function debounceAsync(fn, delay) {
+  let timer;
+  let latestArgs;
+  let resolvers = [];
+  return (...args) => {
+    latestArgs = args;
+    clearTimeout(timer);
+    timer = setTimeout(async () => {
+      const result = await fn(...latestArgs);
+      resolvers.forEach(r => r(result));
+      resolvers = [];
+    }, delay);
+    return new Promise(res => resolvers.push(res));
+  };
+}
+
+// Expose a debounced saveDecisions to batch rapid updates
+export const queueSaveDecisions = debounceAsync(saveDecisions, 250);
+
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { loadDecisions, saveDecisions, generateId } from './helpers.js';
+import { loadDecisions, queueSaveDecisions as saveDecisions, generateId } from './helpers.js';
 import { renderDailyTasks } from './daily.js';
 import { renderGoalsAndSubitems } from './goals.js';
 import { initAuth } from './auth.js';

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -1,6 +1,6 @@
 // ── tasks.js ──
 
-import { loadDecisions, saveDecisions, generateId } from './helpers.js';
+import { loadDecisions, queueSaveDecisions as saveDecisions, generateId } from './helpers.js';
 import { enableTaskDragAndDrop } from './dragAndDrop.js';
 import { createGoalRow } from './goals.js';
 

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -1,5 +1,5 @@
 import { parseNaturalDate } from './helpers.js';
-import { generateId, loadDecisions, saveDecisions, saveGoalOrder } from './helpers.js';
+import { generateId, loadDecisions, queueSaveDecisions as saveDecisions, saveGoalOrder } from './helpers.js';
 import { renderGoalsAndSubitems } from './goals.js';
 import { getCurrentUser } from './auth.js';
 

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -1,5 +1,10 @@
-import { parseNaturalDate } from './helpers.js';
-import { generateId, loadDecisions, queueSaveDecisions as saveDecisions, saveGoalOrder } from './helpers.js';
+import {
+  parseNaturalDate,
+  generateId,
+  loadDecisions,
+  queueSaveDecisions as saveDecisions,
+  saveGoalOrder
+} from './helpers.js';
 import { renderGoalsAndSubitems } from './goals.js';
 import { getCurrentUser } from './auth.js';
 


### PR DESCRIPTION
## Summary
- add a `debounceAsync` helper and expose `queueSaveDecisions`
- swap `saveDecisions` imports for the queued version

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863014eb7d8832785a1ba8b436dceef