### PR TITLE
Improve tab visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -753,26 +753,35 @@ body {
 #goalsView .tabs {
   margin: 0;
   /* remove top margins inherited elsewhere */
-  padding: 8px 0 0 0;
+  padding: 8px;
   display: flex;
   justify-content: flex-start;
+  gap: 8px;
   background-color: #f0f5f2;
   /* subtle contrast under the navbar */
   border-bottom: 1px solid #d0e0d4;
 }
 
 #goalsView .tabs button {
-  margin-right: 12px;
   padding: 8px 16px;
-  background: #7aa68c;
-  color: #fff;
-  border-radius: 4px 4px 0 0;
-  border: 1px solid #638b76;
+  background: #e8efe9;
+  color: #275539;
+  border-radius: 6px 6px 0 0;
+  border: 1px solid #b1c8b6;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out,
+              color 0.2s ease-in-out;
 }
 
-#goalsView .tabs button.active,
-#goalsView .tabs button:hover {
-  background: #638b76;
+#goalsView .tabs button.active {
+  background: #7aa68c;
+  color: #fff;
+  border-color: #638b76;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#goalsView .tabs button:hover:not(.active) {
+  background: #dfe9e2;
 }
 
 #goalsView .tabs .container {


### PR DESCRIPTION
## Summary
- refresh tabs with lighter default color
- highlight active tab using green accent and subtle shadow
- add hover feedback and spacing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run purge:css`

------
https://chatgpt.com/codex/tasks/task_e_6863051a700c83279bdd3ec91b4f8f83