### PR TITLE
Add sample data for unauthenticated visitors

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,5 +1,45 @@
 import { getCurrentUser, db } from './auth.js';
 
+// Demo data for visitors who aren't signed in
+const SAMPLE_DECISIONS = [
+  {
+    id: 'demo-goal',
+    type: 'goal',
+    text: 'Welcome to Goal Oriented',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: null,
+  },
+  {
+    id: 'demo-task-1',
+    type: 'task',
+    text: 'Explore the demo tasks',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal',
+  },
+  {
+    id: 'demo-task-2',
+    type: 'task',
+    text: 'Sign up to save your own goals',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal',
+  },
+  {
+    id: 'demo-goal-2',
+    type: 'goal',
+    text: 'Another sample goal',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: null,
+  }
+];
+
 // Cache decisions in-memory to avoid repeated Firestore reads
 let decisionsCache = null;
 
@@ -14,8 +54,9 @@ export async function loadDecisions(forceRefresh = false) {
 
   const currentUser = getCurrentUser();
   if (!currentUser) {
-    console.warn('🚫 No current user — skipping loadDecisions');
-    return [];
+    console.warn('🚫 No current user — returning sample data');
+    decisionsCache = SAMPLE_DECISIONS;
+    return decisionsCache;
   }
   const snap = await db.collection('decisions').doc(currentUser.uid).get();
   const data = snap.data();

--- a/js/main.js
+++ b/js/main.js
@@ -35,21 +35,23 @@ window.addEventListener('DOMContentLoaded', () => {
   initAuth(uiRefs, async (user) => {
     window.currentUser = user;
 
-    if (!user) {
-      splash.style.display = 'flex';
-      goalsView.style.display = 'none';
-      return;
-    }
-
-    splash.style.display = 'none';
-    goalsView.style.display = '';
-
     ['goalList', 'completedList', 'dailyTasksList'].forEach(id => {
       const el = document.getElementById(id);
       if (el) el.innerHTML = '';
     });
 
     window.openGoalIds?.clear?.();
+
+    if (!user) {
+      splash.style.display = 'flex';
+      goalsView.style.display = '';
+      initTabs(null, db);
+      renderGoalsAndSubitems();
+      return;
+    }
+
+    splash.style.display = 'none';
+    goalsView.style.display = '';
 
     initTabs(user, db);
     renderGoalsAndSubitems(user, db);


### PR DESCRIPTION
## Summary
- provide a built‑in sample dataset when no user is signed in
- allow guest users to see the main interface with demo goals
- skip Firestore lookups if not authenticated

## Testing
- `npm test` *(fails: Missing script)*
- `npm run purge:css` *(fails: purgecss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630582eecc83279840b5631bafa5b5