### PR TITLE
Connect sample data for offline use

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,44 +1,7 @@
 import { getCurrentUser, db } from './auth.js';
+import { SAMPLE_DECISIONS, SAMPLE_LISTS } from './sampleData.js';
 
-// Demo data for visitors who aren't signed in
-const SAMPLE_DECISIONS = [
-  {
-    id: 'demo-goal',
-    type: 'goal',
-    text: 'Welcome to Goal Oriented',
-    completed: false,
-    resolution: '',
-    dateCompleted: '',
-    parentGoalId: null,
-  },
-  {
-    id: 'demo-task-1',
-    type: 'task',
-    text: 'Explore the demo tasks',
-    completed: false,
-    resolution: '',
-    dateCompleted: '',
-    parentGoalId: 'demo-goal',
-  },
-  {
-    id: 'demo-task-2',
-    type: 'task',
-    text: 'Sign up to save your own goals',
-    completed: false,
-    resolution: '',
-    dateCompleted: '',
-    parentGoalId: 'demo-goal',
-  },
-  {
-    id: 'demo-goal-2',
-    type: 'goal',
-    text: 'Another sample goal',
-    completed: false,
-    resolution: '',
-    dateCompleted: '',
-    parentGoalId: null,
-  }
-];
+// Demo data for visitors stored in sampleData.js
 
 // Cache decisions in-memory to avoid repeated Firestore reads
 let decisionsCache = null;
@@ -133,7 +96,11 @@ const LISTS_KEY = 'myLists';
 export async function loadLists() {
   const user = getCurrentUser?.();
   if (!user) {
-    return JSON.parse(localStorage.getItem(LISTS_KEY) || '[]'); // anonymous → localStorage
+    const stored = JSON.parse(localStorage.getItem(LISTS_KEY) || 'null');
+    if (Array.isArray(stored) && stored.length) {
+      return stored; // anonymous → localStorage
+    }
+    return SAMPLE_LISTS.slice();
   }
 
   const doc = await db.collection('lists').doc(user.uid).get();

--- a/js/notes.js
+++ b/js/notes.js
@@ -1,7 +1,14 @@
 import { db } from './auth.js';
+import { generateId } from './helpers.js';
+import { SAMPLE_NOTES } from './sampleData.js';
+let demoNotes = SAMPLE_NOTES.slice();
 
 async function loadNotes() {
-  const uid = firebase.auth().currentUser.uid;
+  const user = firebase.auth().currentUser;
+  if (!user) {
+    return demoNotes;
+  }
+  const uid = user.uid;
   const snapshot = await db
     .collection('dailyNotes')
     .doc(uid)
@@ -20,7 +27,13 @@ async function loadNotes() {
 }
 
 async function saveNote(text) {
-  const uid = firebase.auth().currentUser.uid;
+  const user = firebase.auth().currentUser;
+  if (!user) {
+    const note = { id: generateId(), text, timestamp: new Date().toISOString() };
+    demoNotes.unshift(note);
+    return;
+  }
+  const uid = user.uid;
   await db
     .collection('dailyNotes')
     .doc(uid)

--- a/js/sampleData.js
+++ b/js/sampleData.js
@@ -1,0 +1,190 @@
+export const SAMPLE_DECISIONS = [
+  {
+    id: 'demo-goal',
+    type: 'goal',
+    text: 'Welcome to Goal Oriented',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: null,
+  },
+  {
+    id: 'demo-task-1',
+    type: 'task',
+    text: 'Explore the demo tasks',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal',
+  },
+  {
+    id: 'demo-task-2',
+    type: 'task',
+    text: 'Sign up to save your own goals',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal',
+  },
+  {
+    id: 'demo-task-3',
+    type: 'task',
+    text: 'Try editing and reordering tasks',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal',
+  },
+  {
+    id: 'demo-goal-2',
+    type: 'goal',
+    text: 'Grow your side project',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: null,
+  },
+  {
+    id: 'demo-task-2a',
+    type: 'task',
+    text: 'Outline your MVP features',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal-2',
+  },
+  {
+    id: 'demo-task-2b',
+    type: 'task',
+    text: 'Launch a landing page',
+    completed: true,
+    resolution: '',
+    dateCompleted: '2025-06-20',
+    parentGoalId: 'demo-goal-2',
+  },
+  {
+    id: 'demo-task-2c',
+    type: 'task',
+    text: 'Get your first users',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal-2',
+  },
+  {
+    id: 'demo-goal-3',
+    type: 'goal',
+    text: 'Completed sample goal',
+    completed: true,
+    resolution: '',
+    dateCompleted: '2025-06-15',
+    parentGoalId: null,
+  },
+  {
+    id: 'demo-task-3a',
+    type: 'task',
+    text: 'This is done!',
+    completed: true,
+    resolution: '',
+    dateCompleted: '2025-06-14',
+    parentGoalId: 'demo-goal-3',
+  },
+  {
+    id: 'demo-task-3b',
+    type: 'task',
+    text: 'So is this',
+    completed: true,
+    resolution: '',
+    dateCompleted: '2025-06-15',
+    parentGoalId: 'demo-goal-3',
+  },
+  {
+    id: 'demo-goal-4',
+    type: 'goal',
+    text: 'Future conference talk',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    scheduled: '2025-07-10',
+    parentGoalId: null,
+  },
+  {
+    id: 'demo-task-4a',
+    type: 'task',
+    text: 'Write an outline',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal-4',
+  },
+  {
+    id: 'demo-task-4b',
+    type: 'task',
+    text: 'Create slides',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    parentGoalId: 'demo-goal-4',
+  },
+  {
+    id: 'daily-task-1',
+    type: 'task',
+    text: 'Review tasks each morning',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    recurs: 'daily',
+    parentGoalId: null,
+  },
+  {
+    id: 'daily-task-2',
+    type: 'task',
+    text: 'Plan your week on Monday',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    recurs: 'weekly',
+    parentGoalId: null,
+  },
+  {
+    id: 'daily-task-3',
+    type: 'task',
+    text: 'Share progress on Friday',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    recurs: 'weekly',
+    parentGoalId: null,
+  }
+];
+
+export const SAMPLE_LISTS = [
+  {
+    name: 'Books to Read',
+    columns: [
+      { name: 'Title', type: 'link' },
+      { name: 'Author', type: 'text' }
+    ],
+    items: [
+      { Title: 'https://example.com/book1', Title_label: 'Deep Work', Author: 'Cal Newport' },
+      { Title: 'https://example.com/book2', Title_label: 'Atomic Habits', Author: 'James Clear' }
+    ]
+  },
+  {
+    name: 'Groceries',
+    columns: [
+      { name: 'Item', type: 'text' },
+      { name: 'Qty', type: 'number' }
+    ],
+    items: [
+      { Item: 'Apples', Qty: '3' },
+      { Item: 'Milk', Qty: '1' },
+      { Item: 'Eggs', Qty: '12' }
+    ]
+  }
+];
+
+export const SAMPLE_NOTES = [
+  { id: 'note1', text: 'Welcome to the notes panel!', timestamp: new Date().toISOString() },
+  { id: 'note2', text: 'Sign up to sync your notes.', timestamp: new Date().toISOString() }
+];


### PR DESCRIPTION
## Summary
- restore `sampleData.js` with example goals, lists, and notes
- load demo data in `helpers.js` and `notes.js` for visitors without accounts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68632beeafdc8327b46ea62bc2c5f902