### PR TITLE
Fix sample daily tasks for guests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -47,6 +47,7 @@ window.addEventListener('DOMContentLoaded', () => {
       goalsView.style.display = '';
       initTabs(null, db);
       renderGoalsAndSubitems();
+      renderDailyTasks(null, db);
       return;
     }
 


### PR DESCRIPTION
## Summary
- initialize daily panel when not signed in so sample tasks appear

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686350a20834832798431a72f3995707