### PR TITLE
Add preview and sign-in buttons on splash page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,19 @@
     align-items: center;
     justify-content: center;
     min-height: 100vh;
+    position: relative;
   ">
+    <button id="splashLoginBtn" style="
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      padding: 8px 16px;
+      border-radius: 6px;
+      background-color: #7aa68c;
+      color: white;
+      border: none;
+      cursor: pointer;
+    ">Sign In</button>
     <h1>Welcome to Goal Oriented</h1>
     <p style="max-width: 600px; text-align: center;">
       Track your goals, daily tasks, and metrics—all in one place.
@@ -36,6 +48,16 @@
     ">
       Sign Up
     </button>
+    <button id="previewBtn" style="
+      padding: 10px 20px;
+      font-size: 1em;
+      border-radius: 6px;
+      background-color: #c7c7c7;
+      color: #333;
+      border: none;
+      cursor: pointer;
+      margin-top: 10px;
+    ">Preview</button>
   </section>
 
   <!-- GOALS VIEW (with its own navbar, tabs, and content) -->

--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,8 @@ window.addEventListener('DOMContentLoaded', () => {
     logoutBtn: document.getElementById('logoutBtn'),
     userEmail: document.getElementById('userEmail'),
     signupBtn: document.getElementById('signupBtn'),
+    splashLoginBtn: document.getElementById('splashLoginBtn'),
+    previewBtn: document.getElementById('previewBtn'),
     addGoalBtn: document.getElementById('addGoalBtn'),
     wizardContainer: document.getElementById('goalWizard'),
     wizardStep: document.getElementById('wizardStep'),
@@ -31,6 +33,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const goalsView = document.getElementById('goalsView');
 
   uiRefs.signupBtn.addEventListener('click', () => uiRefs.loginBtn.click());
+  if (uiRefs.splashLoginBtn) {
+    uiRefs.splashLoginBtn.addEventListener('click', () => uiRefs.loginBtn.click());
+  }
+  if (uiRefs.previewBtn) {
+    uiRefs.previewBtn.addEventListener('click', () => {
+      splash.style.display = 'none';
+      goalsView.scrollIntoView({ behavior: 'smooth' });
+    });
+  }
 
   initAuth(uiRefs, async (user) => {
     window.currentUser = user;


### PR DESCRIPTION
## Summary
- enhance splash page with a Preview button
- add sign-in button in the splash page top-right
- wire up preview and splash sign-in events in main script

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68635079528c832789561539aebcdd7c