### PR TITLE
Add basic tab reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
         <hr style="margin: 40px 0;" />
 
         <div id="completedList" class="decision-container"></div>
+        <div id="goalsReport" class="report-panel"></div>
       </div>
     </div>
 
@@ -117,6 +118,9 @@
         <h2>Notes</h2>
         <p>No events today.</p>
       </div>
+      <div class="full-column">
+        <div id="calendarReport" class="report-panel"></div>
+      </div>
     </div>
 
     <!-- DAILY PANEL -->
@@ -129,6 +133,9 @@
         <h2>Weekly</h2>
         <div id="weeklyTasksList" class="decision-container"></div>
       </div>
+      <div class="full-column">
+        <div id="dailyReport" class="report-panel"></div>
+      </div>
     </div>
 
 
@@ -138,6 +145,7 @@
         <h2>Metrics</h2>
         <div id="genericStatsSummary"></div>
         <div id="metricsConfigSection"></div>
+        <div id="metricsReport" class="report-panel"></div>
       </div>
     </div>
 
@@ -153,6 +161,7 @@
       <div class="full-column">
         <h2>Lists</h2>
         <!-- lists.js will inject the form and rendered lists here -->
+        <div id="listsReport" class="report-panel"></div>
       </div>
     </div>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ import { renderDailyTaskReport } from './report.js';
 import { initMetricsUI } from './stats.js';
 import { initTabs } from './tabs.js';
 import { initButtonStyles } from './buttonStyles.js';
+import { initTabReports } from './tabReports.js';
 
 window.currentUser = null;
 
@@ -57,6 +58,7 @@ window.addEventListener('DOMContentLoaded', () => {
       initTabs(null, db);
       renderGoalsAndSubitems();
       renderDailyTasks(null, db);
+      initTabReports(null, db);
       return;
     }
 
@@ -66,6 +68,7 @@ window.addEventListener('DOMContentLoaded', () => {
     initTabs(user, db);
     renderGoalsAndSubitems(user, db);
     renderDailyTasks(user, db);
+    initTabReports(user, db);
 
     if (document.getElementById('reportBody')) {
       renderDailyTaskReport(user, db);

--- a/js/tabReports.js
+++ b/js/tabReports.js
@@ -1,0 +1,31 @@
+import { loadDecisions, loadLists } from './helpers.js';
+
+export async function initTabReports(user, db) {
+  const decisions = await loadDecisions();
+  renderGoalsReport(decisions);
+  renderDailyReport(decisions);
+  const lists = await loadLists();
+  renderListsReport(lists);
+  // Calendar and Metrics tabs currently have no data-driven reports
+}
+
+function renderGoalsReport(items) {
+  const container = document.getElementById('goalsReport');
+  if (!container) return;
+  const goals = items.filter(i => i.type === 'goal');
+  const completed = goals.filter(g => g.completed).length;
+  container.textContent = `Total goals: ${goals.length}. Completed: ${completed}. Pending: ${goals.length - completed}.`;
+}
+
+function renderDailyReport(items) {
+  const container = document.getElementById('dailyReport');
+  if (!container) return;
+  const tasks = items.filter(i => i.type === 'task' && i.recurs === 'daily');
+  container.textContent = `Daily tasks: ${tasks.length}`;
+}
+
+function renderListsReport(lists) {
+  const container = document.getElementById('listsReport');
+  if (!container) return;
+  container.textContent = `Lists: ${lists.length}`;
+}


### PR DESCRIPTION
## Summary
- add report panels for each tab
- populate simple counts with `initTabReports`
- initialize tab reports in `main.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863562173848327916c81f9bdecb243