### PR TITLE
Add DB tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - run: npm install
+    - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "purge:css": "purgecss --config purgecss.config.js --output ./clean-css",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const setMock = vi.fn();
+const updateMock = vi.fn();
+const getMock = vi.fn();
+
+// Simple localStorage mock for Node environment
+const storage = (() => {
+  let store = {};
+  return {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: key => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    }
+  };
+})();
+global.localStorage = storage;
+
+vi.mock('../js/auth.js', () => {
+  return {
+    getCurrentUser: () => ({ uid: 'user1' }),
+    db: {
+      collection: vi.fn(() => ({
+        doc: vi.fn(() => ({
+          get: getMock,
+          set: setMock,
+          update: updateMock
+        }))
+      }))
+    }
+  };
+});
+
+beforeEach(() => {
+  setMock.mockClear();
+  updateMock.mockClear();
+  getMock.mockClear();
+  vi.resetModules();
+  localStorage.clear();
+});
+
+describe('database helpers', () => {
+  it('loads decisions from Firestore', async () => {
+    getMock.mockResolvedValue({ data: () => ({ items: [{ id: '1', text: 't' }] }) });
+    const { loadDecisions } = await import('../js/helpers.js');
+    const result = await loadDecisions(true);
+    expect(result).toEqual([{ id: '1', text: 't' }]);
+    expect(getMock).toHaveBeenCalled();
+  });
+
+  it('saves decisions to Firestore', async () => {
+    const items = [{ id: 'a', text: 'b' }];
+    const { saveDecisions } = await import('../js/helpers.js');
+    await saveDecisions(items);
+    expect(setMock).toHaveBeenCalledWith({ items }, { merge: true });
+  });
+
+  it('saves goal order', async () => {
+    const { saveGoalOrder } = await import('../js/helpers.js');
+    await saveGoalOrder(['a', 'b']);
+    expect(updateMock).toHaveBeenCalledWith({ goalOrder: ['a', 'b'] });
+  });
+
+  it('saves lists for anonymous users to localStorage', async () => {
+    // Remock getCurrentUser to return null
+    vi.doMock('../js/auth.js', () => ({ getCurrentUser: () => null, db: {} }));
+    const { saveLists: saveAnon } = await import('../js/helpers.js');
+    await saveAnon([{ name: 'test' }]);
+    expect(JSON.parse(localStorage.getItem('myLists'))).toEqual([{ name: 'test' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Node.js workflow to run tests on push/PR
- improve `npm test` script to run `vitest` once
- add unit tests for DB helper functions with mocked Firestore

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68635747dc248327993a357b0db62916