### PR TITLE
Add chart-based tab reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
         <hr style="margin: 40px 0;" />
 
         <div id="completedList" class="decision-container"></div>
+        <div id="goalsReport" class="report-panel"></div>
       </div>
     </div>
 
@@ -117,6 +118,9 @@
         <h2>Notes</h2>
         <p>No events today.</p>
       </div>
+      <div class="full-column">
+        <div id="calendarReport" class="report-panel"></div>
+      </div>
     </div>
 
     <!-- DAILY PANEL -->
@@ -129,6 +133,9 @@
         <h2>Weekly</h2>
         <div id="weeklyTasksList" class="decision-container"></div>
       </div>
+      <div class="full-column">
+        <div id="dailyReport" class="report-panel"></div>
+      </div>
     </div>
 
 
@@ -138,6 +145,7 @@
         <h2>Metrics</h2>
         <div id="genericStatsSummary"></div>
         <div id="metricsConfigSection"></div>
+        <div id="metricsReport" class="report-panel"></div>
       </div>
     </div>
 
@@ -153,6 +161,7 @@
       <div class="full-column">
         <h2>Lists</h2>
         <!-- lists.js will inject the form and rendered lists here -->
+        <div id="listsReport" class="report-panel"></div>
       </div>
     </div>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ import { renderDailyTaskReport } from './report.js';
 import { initMetricsUI } from './stats.js';
 import { initTabs } from './tabs.js';
 import { initButtonStyles } from './buttonStyles.js';
+import { initTabReports } from './tabReports.js';
 
 window.currentUser = null;
 
@@ -57,6 +58,7 @@ window.addEventListener('DOMContentLoaded', () => {
       initTabs(null, db);
       renderGoalsAndSubitems();
       renderDailyTasks(null, db);
+      initTabReports(null, db);
       return;
     }
 
@@ -66,6 +68,7 @@ window.addEventListener('DOMContentLoaded', () => {
     initTabs(user, db);
     renderGoalsAndSubitems(user, db);
     renderDailyTasks(user, db);
+    initTabReports(user, db);
 
     if (document.getElementById('reportBody')) {
       renderDailyTaskReport(user, db);

--- a/js/tabReports.js
+++ b/js/tabReports.js
@@ -1,0 +1,99 @@
+import { loadDecisions, loadLists } from './helpers.js';
+
+function getLastNDates(n) {
+  const dates = [];
+  const today = new Date();
+  for (let i = 0; i < n; i++) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    dates.push(d.toISOString().split('T')[0]);
+  }
+  return dates.reverse();
+}
+
+export async function initTabReports(user, db) {
+  const decisions = await loadDecisions();
+  renderGoalsReport(decisions);
+  await renderDailyReport(decisions, user, db);
+  const lists = await loadLists();
+  renderListsReport(lists);
+  // Calendar and Metrics tabs currently have no data-driven reports
+}
+
+function renderGoalsReport(items) {
+  const container = document.getElementById('goalsReport');
+  if (!container) return;
+  const goals = items.filter(i => i.type === 'goal');
+  const completed = goals.filter(g => g.completed).length;
+  container.innerHTML = '<h3>Goal Progress</h3><canvas></canvas>';
+  const ctx = container.querySelector('canvas').getContext('2d');
+  new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Completed', 'Pending'],
+      datasets: [{
+        data: [completed, goals.length - completed],
+        backgroundColor: ['#5cb85c', '#d9534f']
+      }]
+    },
+    options: {
+      plugins: { legend: { position: 'bottom' } },
+      responsive: true
+    }
+  });
+}
+
+async function renderDailyReport(items, user, db) {
+  const container = document.getElementById('dailyReport');
+  if (!container) return;
+  container.innerHTML = '<h3>Daily Completions</h3><canvas></canvas>';
+  const ctx = container.querySelector('canvas').getContext('2d');
+  let completionMap = {};
+  if (user && db) {
+    const snap = await db.collection('taskCompletions').doc(user.uid).get();
+    completionMap = snap.exists ? snap.data() : {};
+  }
+  const labels = getLastNDates(7);
+  const data = labels.map(d => (completionMap[d] || []).length);
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Tasks Done',
+        data,
+        fill: false,
+        borderColor: '#3e95cd'
+      }]
+    },
+    options: { responsive: true }
+  });
+}
+
+function renderListsReport(lists) {
+  const container = document.getElementById('listsReport');
+  if (!container) return;
+  if (!lists.length) {
+    container.textContent = 'No lists yet.';
+    return;
+  }
+  container.innerHTML = '<h3>List Sizes</h3><canvas></canvas>';
+  const ctx = container.querySelector('canvas').getContext('2d');
+  const labels = lists.map(l => l.name);
+  const data = lists.map(l => (l.items || []).length);
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Items',
+        data,
+        backgroundColor: '#5bc0de'
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: { y: { beginAtZero: true } }
+    }
+  });
+}

--- a/style.css
+++ b/style.css
@@ -933,6 +933,13 @@ h2 {
   border: 1px solid #d0decf;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.report-panel canvas {
+  width: 100%;
+  max-width: 100%;
+}
+
 /* Ensure list tables remain readable on mobile */
 #listsPanel table {
   width: 100%;


### PR DESCRIPTION
## Summary
- use Chart.js for tab-specific charts
- show goal completion as a doughnut chart
- plot daily task completions over the last week
- visualize list sizes in a bar chart
- add responsive styles for report canvases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863562173848327916c81f9bdecb243