### PR TITLE
Fix sample metric retention when adding values offline

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -125,7 +125,10 @@ async function recordMetric(metricId, value, extra = null) {
   };
 
   if (!user) {
-    const all = JSON.parse(localStorage.getItem(STATS_KEY) || '{}');
+    let all = JSON.parse(localStorage.getItem(STATS_KEY) || 'null');
+    if (!all || !Object.keys(all).length) {
+      all = JSON.parse(JSON.stringify(SAMPLE_METRIC_DATA));
+    }
     const day = todayKey();
     all[day] = all[day] || {};
     all[day][metricId] = all[day][metricId] || [];


### PR DESCRIPTION
## Summary
- preserve bundled sample stats when recording metrics while signed out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686402a9bf388327a372800dea4d68af