### PR TITLE
Fix metric editing input

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -373,18 +373,15 @@ async function renderStatsSummary() {
         inp.min = '1';
         inp.max = '10';
         inp.step = '1';
-        inp.placeholder = '1–10';
       } else if (cfg.unit === 'list') {
         inp = document.createElement('textarea');
         inp.rows = 4;
         inp.style.width = '100%';
-        inp.placeholder = cfg.unitLabel;
       } else {
         inp = document.createElement('input');
         inp.type = 'text';
-        inp.placeholder = cfg.unitLabel;
       }
-      inp.value = editValue || display;
+      inp.value = editValue;
       td2.appendChild(inp);
       const saveIcon = document.createElement('span');
       saveIcon.textContent = '💾';


### PR DESCRIPTION
## Summary
- remove placeholder attributes and `—` value from metric edit inputs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864379650c083279c9e976c571f865f