### PR TITLE
Fix active tasks count in goals report

### DIFF
--- a/js/tabReports.js
+++ b/js/tabReports.js
@@ -20,7 +20,7 @@ export async function initTabReports(user, db) {
   // Calendar and Metrics tabs currently have no data-driven reports
 }
 
-function renderGoalsReport(items) {
+export function renderGoalsReport(items) {
   const container = document.getElementById('goalsReport');
   if (!container) return;
 
@@ -37,9 +37,14 @@ function renderGoalsReport(items) {
     return hideUntil && now < hideUntil;
   });
 
+  const goalMap = Object.fromEntries(goals.map(g => [g.id, g]));
+
   const activeTasks = tasks.filter(t => {
     const hideUntil = t.hiddenUntil ? Date.parse(t.hiddenUntil) || 0 : 0;
-    return !t.completed && (!hideUntil || now >= hideUntil);
+    const parent = t.parentGoalId ? goalMap[t.parentGoalId] : null;
+    const parentActive = !parent || (!parent.completed &&
+      (!(parent.hiddenUntil) || now >= (Date.parse(parent.hiddenUntil) || 0)));
+    return !t.completed && parentActive && (!hideUntil || now >= hideUntil);
   });
   const hiddenTasks = tasks.filter(t => {
     const hideUntil = t.hiddenUntil ? Date.parse(t.hiddenUntil) || 0 : 0;

--- a/tests/tabReports.test.js
+++ b/tests/tabReports.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { vi } from 'vitest';
+vi.mock('../js/helpers.js', () => ({
+  loadDecisions: vi.fn(),
+  loadLists: vi.fn()
+}));
+import { renderGoalsReport } from '../js/tabReports.js';
+
+describe('renderGoalsReport', () => {
+  it('counts only active uncompleted tasks', () => {
+    const container = { innerHTML: '', textContent: '' };
+    global.document = {
+      getElementById: (id) => (id === 'goalsReport' ? container : null)
+    };
+    const items = [
+      { id: 'g1', type: 'goal', completed: false },
+      { id: 't1', type: 'task', parentGoalId: 'g1', completed: false },
+      { id: 't2', type: 'task', parentGoalId: 'g1', completed: true },
+      { id: 'g2', type: 'goal', completed: true },
+      { id: 't3', type: 'task', parentGoalId: 'g2', completed: false },
+      { id: 't4', type: 'task', parentGoalId: 'g2', completed: true },
+      { id: 't5', type: 'task', completed: false }
+    ];
+
+    renderGoalsReport(items);
+
+    expect(container.innerHTML).toContain('Active goals: 1');
+    expect(container.innerHTML).toContain('Active tasks: 2');
+  });
+});


### PR DESCRIPTION
## Summary
- export and update `renderGoalsReport` to ignore tasks from completed or hidden goals
- add regression test for active task count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643eda1ce88327b171164ac6421eeb