### PR TITLE
Fix metric edit focus

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -386,6 +386,7 @@ async function renderStatsSummary() {
       }
       inp.value = editValue;
       td2.appendChild(inp);
+      inp.focus();
       const saveIcon = document.createElement('span');
       saveIcon.textContent = '💾';
       saveIcon.style.cursor = 'pointer';


### PR DESCRIPTION
## Summary
- focus metric input when editing a metric value so the cursor is immediately in the box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643fd1846c8327bbfcd08bb65886dc