### PR TITLE
Fix duplicate goals after sign in/out

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -28,13 +28,13 @@ export function initAuth({ loginBtn, logoutBtn, userEmail }, onLogin) {
   };
 
   loginBtn.onclick = async () => {
-    const provider = new firebase.auth.GoogleAuthProvider(); // ✅ FIXED
+    const provider = new firebase.auth.GoogleAuthProvider();
     try {
-      const result = await firebase.auth().signInWithPopup(provider); // ✅ call firebase.auth()
+      const result = await firebase.auth().signInWithPopup(provider);
       currentUser = result.user;
       clearDecisionsCache();
       safeSet(userEmail, 'textContent', currentUser.email);
-      onLogin(currentUser);
+      // onAuthStateChanged will trigger onLogin
     } catch (err) {
       console.error('Login failed:', err);
     }
@@ -49,7 +49,7 @@ export function initAuth({ loginBtn, logoutBtn, userEmail }, onLogin) {
     safeSet(userEmail, 'textContent', '');
     safeSet(loginBtn, 'style', 'display: inline-block');
     safeSet(logoutBtn, 'style', 'display: none');
-    onLogin(null);
+    // onAuthStateChanged will trigger onLogin
   };
 
   auth.onAuthStateChanged(user => {

--- a/js/goals.js
+++ b/js/goals.js
@@ -19,6 +19,8 @@ import {
 
 
 const openGoalIds = new Set();
+// Expose for cleanup between sign-ins
+window.openGoalIds = openGoalIds;
 const goalList = document.getElementById('goalList');
 const completedList = document.getElementById('completedList');
 


### PR DESCRIPTION
## Summary
- avoid calling `onLogin()` twice during login/logout
- expose `openGoalIds` globally for cleanup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686440143124832791720ba66581cebd