### PR TITLE
Fix table overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -934,6 +934,7 @@ h2 {
   border: 1px solid #d0decf;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  overflow-x: auto; /* allow wide tables to scroll */
 }
 
 .report-panel canvas {
@@ -955,6 +956,11 @@ h2 {
 
 @media (max-width: 600px) {
   #listsContainer {
+    overflow-x: auto;
+  }
+  /* tables inside report panels and stats summary should scroll */
+  .report-panel,
+  #genericStatsSummary {
     overflow-x: auto;
   }
 }


### PR DESCRIPTION
## Summary
- allow tables inside `.report-panel` to scroll horizontally
- add a responsive rule so report panels and the stats summary don't overflow on small screens

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68644efae3f88327b485c7f3634ecf23