### PR TITLE
Add Google Calendar integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,10 @@
       </div>
       <div class="right-column">
         <h2>Notes</h2>
+        <div id="googleCalendarSection">
+          <button id="connectCalendarBtn" type="button">Connect Google Calendar</button>
+          <ul id="googleEvents"></ul>
+        </div>
         <p>No events today.</p>
       </div>
       <div class="full-column">
@@ -170,6 +174,7 @@
     </div>
   </section>
 
+  <script src="https://apis.google.com/js/api.js"></script>
   <script type="module" src="js/main.js"></script>
   <script type="module" src="js/lists.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/js/googleCalendar.js
+++ b/js/googleCalendar.js
@@ -1,0 +1,56 @@
+export function initGoogleCalendar() {
+  const connectBtn = document.getElementById('connectCalendarBtn');
+  const listEl = document.getElementById('googleEvents');
+  if (!connectBtn || !listEl) return;
+
+  const API_KEY = 'AIzaSyBbet_bmwm8h8G5CqvmzrdAnc3AO-0IKa8';
+  const CLIENT_ID = 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com';
+  const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'];
+  const SCOPES = 'https://www.googleapis.com/auth/calendar.readonly';
+
+  function showEvents(events) {
+    listEl.innerHTML = '';
+    if (!events || !events.length) {
+      listEl.textContent = 'No upcoming events';
+      return;
+    }
+    events.forEach(ev => {
+      const li = document.createElement('li');
+      const start = ev.start.dateTime || ev.start.date || '';
+      li.textContent = `${start.slice(0,16)} - ${ev.summary}`;
+      listEl.appendChild(li);
+    });
+  }
+
+  function listUpcomingEvents() {
+    gapi.client.calendar.events.list({
+      calendarId: 'primary',
+      timeMin: new Date().toISOString(),
+      showDeleted: false,
+      singleEvents: true,
+      maxResults: 10,
+      orderBy: 'startTime'
+    }).then(res => {
+      showEvents(res.result.items);
+    }, err => {
+      console.error('Calendar API error', err);
+      listEl.textContent = 'Failed to load events';
+    });
+  }
+
+  connectBtn.addEventListener('click', () => {
+    gapi.load('client:auth2', () => {
+      gapi.client.init({
+        apiKey: API_KEY,
+        clientId: CLIENT_ID,
+        discoveryDocs: DISCOVERY_DOCS,
+        scope: SCOPES
+      }).then(() => gapi.auth2.getAuthInstance().signIn())
+        .then(listUpcomingEvents)
+        .catch(err => {
+          console.error('Auth or API error', err);
+          listEl.textContent = 'Unable to connect to Google Calendar';
+        });
+    });
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ import { initMetricsUI } from './stats.js';
 import { initTabs } from './tabs.js';
 import { initButtonStyles } from './buttonStyles.js';
 import { initTabReports } from './tabReports.js';
+import { initGoogleCalendar } from './googleCalendar.js';
 
 window.currentUser = null;
 
@@ -85,6 +86,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   initButtonStyles();
+  initGoogleCalendar();
 });
 
 window.loadDecisions = loadDecisions;


### PR DESCRIPTION
## Summary
- extend calendar panel with a Connect button
- add script to fetch Google Calendar events via gapi
- load gapi and initialise calendar integration

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68658b2732408327948b9e8f202421f2