### PR TITLE
Improve goal edit dropdown

### DIFF
--- a/js/goals.js
+++ b/js/goals.js
@@ -544,7 +544,11 @@ function attachEditButtons(item, buttonWrap) {
             scheduledInput.style.width = '140px';
 
             const allItems = await loadDecisions();
-            const goals = allItems.filter(g => g.type === 'goal' && g.id !== item.id);
+            const goals = allItems.filter(g =>
+                g.type === 'goal' &&
+                g.id !== item.id &&
+                !g.completed // only active or hidden
+            );
             const noneOpt = document.createElement('option');
             noneOpt.value = '';
             noneOpt.textContent = '(no parent)';
@@ -557,6 +561,7 @@ function attachEditButtons(item, buttonWrap) {
                 parentSelect.appendChild(opt);
             });
             parentSelect.style.marginLeft = '8px';
+            parentSelect.style.maxWidth = '160px';
 
             middle.innerHTML = '';
             middle.appendChild(textInput);

--- a/style.css
+++ b/style.css
@@ -189,9 +189,10 @@ button:hover {
 
 .right-group {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
   min-width: 200px;
   max-width: 260px;
   flex-shrink: 0;
@@ -201,7 +202,7 @@ button:hover {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: flex-end;
 }
 
 /* Other rules remain unchanged below... */
@@ -389,6 +390,7 @@ button:hover {
     flex: 0 0 auto;
     font-size: 0.9em;
     flex-wrap: nowrap;
+    justify-content: flex-end;
   }
 
   .title-column {
@@ -399,7 +401,7 @@ button:hover {
   .button-row {
     flex-wrap: nowrap;
     gap: 6px;
-    justify-content: space-evenly;
+    justify-content: flex-end;
   }
 
   .button-row button {


### PR DESCRIPTION
## Summary
- style goal edit buttons and parent dropdown
- keep dropdown options to active or hidden goals
- tweak alignment in goal rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68671e11ee808327bbd170c7c9e7ea82