### PR TITLE
Add monthly tasks section

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <div class="tabs">
       <button class="tab-button active" data-target="goalsPanel">Goals</button>
       <button class="tab-button" data-target="calendarPanel">Calendar</button>
-      <button class="tab-button" data-target="dailyPanel">Daily</button>
+      <button class="tab-button" data-target="dailyPanel">Recurring</button>
       <button class="tab-button" data-target="metricsPanel">Metrics</button>
       <button class="tab-button" data-target="listsPanel">Lists</button>
     </div>
@@ -136,6 +136,10 @@
       <div class="right-column">
         <h2>Weekly</h2>
         <div id="weeklyTasksList" class="decision-container"></div>
+      </div>
+      <div class="right-column">
+        <h2>Monthly</h2>
+        <div id="monthlyTasksList" class="decision-container"></div>
       </div>
       <div class="full-column">
         <div id="dailyReport" class="report-panel"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -46,7 +46,7 @@ window.addEventListener('DOMContentLoaded', () => {
   initAuth(uiRefs, async (user) => {
     window.currentUser = user;
 
-    ['goalList', 'completedList', 'dailyTasksList', 'weeklyTasksList'].forEach(id => {
+    ['goalList', 'completedList', 'dailyTasksList', 'weeklyTasksList', 'monthlyTasksList'].forEach(id => {
       const el = document.getElementById(id);
       if (el) el.innerHTML = '';
     });

--- a/js/sampleData.js
+++ b/js/sampleData.js
@@ -225,6 +225,16 @@ export const SAMPLE_DECISIONS = [
     dateCompleted: '',
     recurs: 'daily',
     parentGoalId: null,
+  },
+  {
+    id: 'daily-task-11',
+    type: 'task',
+    text: 'Review monthly goals',
+    completed: false,
+    resolution: '',
+    dateCompleted: '',
+    recurs: 'monthly',
+    parentGoalId: null,
   }
 ];
 


### PR DESCRIPTION
## Summary
- rename Daily tab to Recurring
- show monthly tasks next to daily and weekly tasks
- allow adding monthly tasks
- reset monthly list on login/logout
- include sample monthly task

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68671fd22b5c83279b6c3b491b69755c