### PR TITLE
Add Travel tab with KML import

### DIFF
--- a/assets/travel/doc.xml
+++ b/assets/travel/doc.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>Untitled layer</name>
+    <Style id="icon-503-62AF44-normal">
+      <IconStyle>
+        <color>ff44af62</color>
+        <scale>1.1</scale>
+        <Icon>
+          <href>https://www.gstatic.com/mapspro/images/stock/503-wht-blank_maps.png</href>
+        </Icon>
+        <hotSpot x="16" xunits="pixels" y="32" yunits="insetPixels"/>
+      </IconStyle>
+      <LabelStyle>
+        <scale>0</scale>
+      </LabelStyle>
+    </Style>
+    <Style id="icon-503-62AF44-highlight">
+      <IconStyle>
+        <color>ff44af62</color>
+        <scale>1.1</scale>
+        <Icon>
+          <href>https://www.gstatic.com/mapspro/images/stock/503-wht-blank_maps.png</href>
+        </Icon>
+        <hotSpot x="16" xunits="pixels" y="32" yunits="insetPixels"/>
+      </IconStyle>
+      <LabelStyle>
+        <scale>1.1</scale>
+      </LabelStyle>
+    </Style>
+    <StyleMap id="icon-503-62AF44">
+      <Pair>
+        <key>normal</key>
+        <styleUrl>#icon-503-62AF44-normal</styleUrl>
+      </Pair>
+      <Pair>
+        <key>highlight</key>
+        <styleUrl>#icon-503-62AF44-highlight</styleUrl>
+      </Pair>
+    </StyleMap>
+    <Style id="icon-503-DB4436-normal">
+      <IconStyle>
+        <color>ff3644db</color>
+        <scale>1.1</scale>
+        <Icon>
+          <href>https://www.gstatic.com/mapspro/images/stock/503-wht-blank_maps.png</href>
+        </Icon>
+        <hotSpot x="16" xunits="pixels" y="32" yunits="insetPixels"/>
+      </IconStyle>
+      <LabelStyle>
+        <scale>0</scale>
+      </LabelStyle>
+    </Style>
+    <Style id="icon-503-DB4436-highlight">
+      <IconStyle>
+        <color>ff3644db</color>
+        <scale>1.1</scale>
+        <Icon>
+          <href>https://www.gstatic.com/mapspro/images/stock/503-wht-blank_maps.png</href>
+        </Icon>
+        <hotSpot x="16" xunits="pixels" y="32" yunits="insetPixels"/>
+      </IconStyle>
+      <LabelStyle>
+        <scale>1.1</scale>
+      </LabelStyle>
+    </Style>
+    <StyleMap id="icon-503-DB4436">
+      <Pair>
+        <key>normal</key>
+        <styleUrl>#icon-503-DB4436-normal</styleUrl>
+      </Pair>
+      <Pair>
+        <key>highlight</key>
+        <styleUrl>#icon-503-DB4436-highlight</styleUrl>
+      </Pair>
+    </StyleMap>
+    <Placemark>
+      <name>1808 Newton St NW</name>
+      <description><![CDATA[description: Lived here 2011-2013. Ridiculously small place, rented to save money until I got a decent job after grad school. <br>Pictures: <br>Interest Rating: <br>Rating: <br>Date: 2011-2013]]></description>
+      <styleUrl>#icon-503-62AF44</styleUrl>
+      <ExtendedData>
+        <Data name="description">
+          <value>Lived here 2011-2013. Ridiculously small place, rented to save money until I got a decent job after grad school. </value>
+        </Data>
+        <Data name="Pictures">
+          <value/>
+        </Data>
+        <Data name="Interest Rating">
+          <value/>
+        </Data>
+        <Data name="Rating">
+          <value/>
+        </Data>
+        <Data name="Date">
+          <value>2011-2013</value>
+        </Data>
+      </ExtendedData>
+      <Point>
+        <coordinates>
+          -77.041743,38.933928,0
+        </coordinates>
+      </Point>
+    </Placemark>
+  </Document>
+</kml>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
       <button class="tab-button" data-target="dailyPanel">Recurring</button>
       <button class="tab-button" data-target="metricsPanel">Metrics</button>
       <button class="tab-button" data-target="listsPanel">Lists</button>
+      <button class="tab-button" data-target="travelPanel">Travel</button>
     </div>
 
     <!-- TABS CONTENT PANELS -->
@@ -176,11 +177,21 @@
         <div id="listsReport" class="report-panel"></div>
       </div>
     </div>
+
+    <!-- TRAVEL PANEL -->
+    <div id="travelPanel" class="main-layout" style="display:none">
+      <div class="full-column">
+        <h2>Travel <button id="addPlaceBtn" type="button">+ Add Place</button></h2>
+        <canvas id="travelMap" width="720" height="360" style="border:1px solid #ccc; max-width:100%; height:auto;"></canvas>
+        <ul id="travelList"></ul>
+      </div>
+    </div>
   </section>
 
   <script src="https://apis.google.com/js/api.js"></script>
   <script type="module" src="js/main.js"></script>
   <script type="module" src="js/lists.js"></script>
+  <script type="module" src="js/travel.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
 </body>

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -6,7 +6,7 @@ export function initTabs(currentUser, db) {
   tabsInitialized = true;
 
   const tabButtons = document.querySelectorAll('.tab-button');
-  const panels    = ['goalsPanel','calendarPanel','dailyPanel','metricsPanel','listsPanel'];
+  const panels    = ['goalsPanel','calendarPanel','dailyPanel','metricsPanel','listsPanel','travelPanel'];
 
   tabButtons.forEach(btn => {
     btn.addEventListener('click', async () => {
@@ -34,6 +34,9 @@ export function initTabs(currentUser, db) {
       else if (target === 'listsPanel') {
         await window.initListsPanel(window.currentUser, db);
       }
+      else if (target === 'travelPanel') {
+        await window.initTravelPanel();
+      }
     });
   });
 
@@ -57,6 +60,9 @@ export function initTabs(currentUser, db) {
     }
     else if (initial === 'listsPanel') {
       window.initListsPanel(window.currentUser, db);
+    }
+    else if (initial === 'travelPanel') {
+      window.initTravelPanel();
     }
   });
 }

--- a/js/travel.js
+++ b/js/travel.js
@@ -1,0 +1,67 @@
+let mapInitialized = false;
+let travelData = [];
+
+function latLngToPoint(lat, lon, width, height) {
+  // Equirectangular projection for simple canvas map
+  const x = (lon + 180) * (width / 360);
+  const y = (90 - lat) * (height / 180);
+  return { x, y };
+}
+
+export async function initTravelPanel() {
+  const panel = document.getElementById('travelPanel');
+  if (!panel || mapInitialized) return;
+  mapInitialized = true;
+
+  const canvas = document.getElementById('travelMap');
+  const list = document.getElementById('travelList');
+  const ctx = canvas.getContext('2d');
+
+  travelData = JSON.parse(localStorage.getItem('travelData') || 'null');
+  if (!travelData) {
+    const res = await fetch('assets/travel/doc.xml');
+    const text = await res.text();
+    travelData = parseKml(text);
+    localStorage.setItem('travelData', JSON.stringify(travelData));
+  }
+
+  function render() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    list.innerHTML = '';
+    travelData.forEach(p => {
+      const { x, y } = latLngToPoint(p.lat, p.lon, canvas.width, canvas.height);
+      ctx.fillStyle = 'red';
+      ctx.beginPath();
+      ctx.arc(x, y, 4, 0, 2 * Math.PI);
+      ctx.fill();
+      const li = document.createElement('li');
+      li.textContent = `${p.name} (${p.lat.toFixed(4)}, ${p.lon.toFixed(4)})`;
+      list.append(li);
+    });
+  }
+
+  document.getElementById('addPlaceBtn').addEventListener('click', () => {
+    const name = prompt('Place name:');
+    const lat = parseFloat(prompt('Latitude:'));
+    const lon = parseFloat(prompt('Longitude:'));
+    if (!name || Number.isNaN(lat) || Number.isNaN(lon)) return;
+    travelData.push({ name, lat, lon });
+    localStorage.setItem('travelData', JSON.stringify(travelData));
+    render();
+  });
+
+  render();
+}
+
+function parseKml(text) {
+  const doc = new DOMParser().parseFromString(text, 'application/xml');
+  const placemarks = Array.from(doc.querySelectorAll('Placemark'));
+  return placemarks.map(pm => {
+    const name = pm.querySelector('name')?.textContent || 'Unknown';
+    const coords = pm.querySelector('coordinates')?.textContent.trim() || '0,0,0';
+    const [lon, lat] = coords.split(',').map(parseFloat);
+    return { name, lat, lon };
+  });
+}
+
+window.initTravelPanel = initTravelPanel;


### PR DESCRIPTION
## Summary
- create Travel tab and panel for viewing travel locations
- import initial placemarks from `assets/travel/doc.xml`
- allow adding new places and persisting them in localStorage
- hook Travel tab into tab system

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699ba4db388327abbd4b1d0cc54fbf