### PR TITLE
Fix travel tab initialization after DOMContentLoaded

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -53,8 +53,9 @@ export function initTabs(currentUser, db) {
     el.style.display = (id === initial) ? 'flex' : 'none';
   });
 
-  // on load, fire any needed init
-  document.addEventListener('DOMContentLoaded', () => {
+  // on load, fire any needed init. If DOMContentLoaded already fired,
+  // run immediately instead of waiting for the event.
+  const runInitial = () => {
     if (initial === 'metricsPanel') {
       window.initMetricsUI();
     }
@@ -64,5 +65,11 @@ export function initTabs(currentUser, db) {
     else if (initial === 'travelPanel') {
       window.initTravelPanel();
     }
-  });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runInitial);
+  } else {
+    runInitial();
+  }
 }


### PR DESCRIPTION
## Summary
- ensure tab initialization runs even if DOMContentLoaded has fired

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686accee2d5083278cf0fd2626ecb9a3