### PR TITLE
Fix postponed metrics visibility

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -341,6 +341,12 @@ async function renderStatsSummary(dayKey = activeMetricsDate) {
     const entries = ((allStats[today] || {})[cfg.id]) || [];
     const validEntries = entries.filter(e => !(e.extra && e.extra.postponed));
     const wasPostponed = entries.some(e => e.extra && e.extra.postponed);
+
+    // Hide metrics that were postponed for today until the next day
+    if (today === todayKey() && wasPostponed && !validEntries.length) {
+      continue;
+    }
+
     visible++;
     let display = '—', editValue = '', pct = '—', rank = '—';
     if (validEntries.length) {


### PR DESCRIPTION
## Summary
- avoid showing metrics on the same day when postponed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ace015b3883278eec6c73f6e96a0b