### PR TITLE
Restore server.js for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,3 @@ js/serviceAccountKey.json
 serviceAccountKey.json
 
 clean-css
-backend

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-#Goal Oriented
+# Goal Oriented
 
 An app for tracking goals and tasks.
 
 👉 **Live App:** [https://davidanderson3.github.io/goal-oriented/](https://davidanderson3.github.io/goal-oriented/)
 
+## Local Development
+
+1. Install dependencies with `npm install`.
+2. Start the local server with:
+   ```bash
+   node backend/server.js
+   ```
+   Then open [http://localhost:3001](http://localhost:3001) in your browser.
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = 3001;
+
+// Serve static files (like index.html, style.css, script.js)
+app.use(express.static(path.resolve(__dirname, '../')));
+
+// Enable CORS (optional for Firebase, useful for local testing)
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  next();
+});
+
+app.listen(PORT, () => {
+  console.log(`✅ Serving static files at http://localhost:${PORT}`);
+});
+
+// 👇 Prevent Node from exiting
+setInterval(() => { }, 1000);


### PR DESCRIPTION
## Summary
- restore simple Express server to serve files locally
- document local server usage in README
- remove `backend` from `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686acc92baf88327b897e88dba505210