### PR TITLE
Add subgoals and calendar date to wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 An app for tracking goals and tasks.
 
+## Recent updates
+
+- New goal wizard creates subgoals instead of subtasks.
+- Goals can now be scheduled directly on your calendar during creation.
+
 👉 **Live App:** [https://davidanderson3.github.io/goal-oriented/](https://davidanderson3.github.io/goal-oriented/)
 
 


### PR DESCRIPTION
## Summary
- support subgoals instead of subtasks in the goal wizard
- allow optional scheduling when creating a goal
- document new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ad29baeac832782af73c193762260