### PR TITLE
Update travel KML import

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "express": "^5.1.0",
     "firebase": "^11.8.1",
-    "firebase-admin": "^13.4.0"
+    "firebase-admin": "^13.4.0",
+    "fast-xml-parser": "^4.5.3"
   },
   "devDependencies": {
     "purgecss": "^7.0.2",

--- a/scripts/importTravelKml.js
+++ b/scripts/importTravelKml.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { XMLParser } = require('fast-xml-parser');
 const admin = require('firebase-admin');
 
 const serviceAccount = require('./serviceAccountKey.json');
@@ -9,30 +10,61 @@ admin.initializeApp({
 
 const db = admin.firestore();
 
-async function main() {
-  const text = fs.readFileSync('assets/travel/doc.kml', 'utf8');
-  const regex = /<Placemark>([\s\S]*?)<\/Placemark>/g;
-  const places = [];
-  let m;
+function parseKml(text) {
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const obj = parser.parse(text);
+  const placemarks = obj.kml.Document.Placemark || [];
+  return placemarks.map(pm => {
+    const coords = pm.Point?.coordinates?.trim();
+    const [lon, lat] = coords ? coords.split(',').map(Number) : [NaN, NaN];
+    const extended = {};
+    if (pm.ExtendedData && pm.ExtendedData.Data) {
+      const dataArr = Array.isArray(pm.ExtendedData.Data) ? pm.ExtendedData.Data : [pm.ExtendedData.Data];
+      dataArr.forEach(d => {
+        if (d['@_name']) extended[d['@_name']] = d.value || '';
+      });
+    }
+    return {
+      name: pm.name?.trim() || 'Unknown',
+      description: pm.description || '',
+      styleUrl: pm.styleUrl || '',
+      lat,
+      lon,
+      ...extended
+    };
+  }).filter(p => !Number.isNaN(p.lat) && !Number.isNaN(p.lon));
+}
 
-  while ((m = regex.exec(text))) {
-    const block = m[1];
-    const name = /<name>([\s\S]*?)<\/name>/.exec(block)?.[1].trim() || 'Unknown';
-    const coords = /<coordinates>([\s\S]*?)<\/coordinates>/.exec(block)?.[1].trim();
-    if (!coords) continue;
-    const [lon, lat] = coords.split(',').map(Number);
-    if (!isNaN(lat) && !isNaN(lon)) {
-      places.push({ name, lat, lon });
+async function clearCollection(coll) {
+  const snap = await coll.get();
+  await Promise.all(snap.docs.map(doc => doc.ref.delete()));
+}
+
+async function importPlaces(places) {
+  const batchSize = 400;
+  let batch = db.batch();
+  let count = 0;
+  for (const place of places) {
+    const ref = db.collection('travel').doc();
+    batch.set(ref, place);
+    count++;
+    if (count % batchSize === 0) {
+      await batch.commit();
+      batch = db.batch();
     }
   }
+  if (count % batchSize !== 0) {
+    await batch.commit();
+  }
+}
 
-  const batch = db.batch();
-  places.forEach(p => {
-    const ref = db.collection('travel').doc();
-    batch.set(ref, p);
-  });
+async function main() {
+  const text = fs.readFileSync('assets/travel/doc.kml', 'utf8');
+  const places = parseKml(text);
 
-  await batch.commit();
+  await clearCollection(db.collection('travel'));
+  await importPlaces(places);
+
   console.log(`Imported ${places.length} places`);
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- parse full KML placemark data with fast-xml-parser
- wipe existing `travel` collection before importing
- include `fast-xml-parser` in dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686af704a74c8327b5d5cb7a7d86c4de