### PR TITLE
Enhance travel list interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
     <div id="travelPanel" class="main-layout" style="display:none">
       <div class="full-column">
         <h2>Travel <button id="addPlaceBtn" type="button">+ Add Place</button></h2>
+        <input id="travelSearch" type="text" placeholder="Search places..." style="margin-bottom:8px;max-width:260px;">
         <div id="travelMap" style="height:360px; max-width:100%; border:1px solid #ccc;"></div>
         <ul id="travelList"></ul>
       </div>


### PR DESCRIPTION
## Summary
- add search bar in Travel section
- support inline editing for place details while keeping coordinates read-only
- style edit/delete buttons without the global green background
- display all travel fields in map list
- auto-open marker when search matches one item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686afbbf597483278bb5875a291079a7