### PR TITLE
Fix calendar missing upcoming weekend

### DIFF
--- a/js/goals.js
+++ b/js/goals.js
@@ -267,8 +267,13 @@ function renderCalendarSection(all, calendarContent) {
     }
 
     const dateKeys = Object.keys(byDate).sort();
-    let start = dateKeys.length ? parseKey(dateKeys[0]) : new Date();
+    let start = new Date();
     start.setHours(0, 0, 0, 0);
+    if (dateKeys.length) {
+        const first = parseKey(dateKeys[0]);
+        first.setHours(0, 0, 0, 0);
+        if (first < start) start = first;
+    }
 
     let end = dateKeys.length ? parseKey(dateKeys[dateKeys.length - 1]) : new Date(start);
     const extendEnd = new Date(start);


### PR DESCRIPTION
## Summary
- fix how the calendar chooses its starting date so upcoming days appear
- keep showing earlier scheduled events if they exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686afeb52fec83278dc7e3a16f7a6a7e