### PR TITLE
Skip past weekends in calendar

### DIFF
--- a/js/goals.js
+++ b/js/goals.js
@@ -280,6 +280,9 @@ function renderCalendarSection(all, calendarContent) {
     extendEnd.setMonth(extendEnd.getMonth() + 6);
     if (extendEnd > end) end = extendEnd;
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
     for (let d = new Date(start); d <= end;) {
         const key = keyFromDate(d);
         const dow = d.getDay();
@@ -287,6 +290,10 @@ function renderCalendarSection(all, calendarContent) {
         if (dow === 6) {
             const sat = new Date(d);
             const sun = new Date(d); sun.setDate(d.getDate() + 1);
+            if (sun < today) {
+                d.setDate(d.getDate() + 2);
+                continue;
+            }
             const sunKey = keyFromDate(sun);
 
             const section = document.createElement('div');
@@ -321,6 +328,10 @@ function renderCalendarSection(all, calendarContent) {
             d.setDate(d.getDate() + 2);
         } else if (dow === 0) {
             const sat = new Date(d); sat.setDate(d.getDate() - 1);
+            if (d < today) {
+                d.setDate(d.getDate() + 1);
+                continue;
+            }
             const satKey = keyFromDate(sat);
 
             const section = document.createElement('div');


### PR DESCRIPTION
## Summary
- ignore weekends that have already passed when rendering the calendar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b0052f4fc8327aae8f3d930212f14