### PR TITLE
Display more fields in travel table

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,14 @@
         <div id="travelMap" style="height:360px; max-width:100%; border:1px solid #ccc;"></div>
         <table id="travelTable">
           <thead>
-            <tr><th>Name</th><th>Tags</th><th>Visited</th><th>Actions</th></tr>
+            <tr>
+              <th>Name</th>
+              <th>Tags</th>
+              <th>Rating</th>
+              <th>Date</th>
+              <th>Visited</th>
+              <th>Actions</th>
+            </tr>
           </thead>
           <tbody></tbody>
         </table>

--- a/js/travel.js
+++ b/js/travel.js
@@ -55,6 +55,10 @@ export async function initTravelPanel() {
       nameTd.textContent = p.name;
       const tagsTd = document.createElement('td');
       tagsTd.textContent = Array.isArray(p.tags) ? p.tags.join(', ') : '';
+      const ratingTd = document.createElement('td');
+      ratingTd.textContent = p.Rating || '';
+      const dateTd = document.createElement('td');
+      dateTd.textContent = p.Date || '';
       const visitedTd = document.createElement('td');
       visitedTd.textContent = p.visited ? '✅' : '';
       const actionsTd = document.createElement('td');
@@ -72,7 +76,7 @@ export async function initTravelPanel() {
         form.style.flexWrap = 'wrap';
         form.style.gap = '4px';
         const td = document.createElement('td');
-        td.colSpan = 4;
+        td.colSpan = 6;
 
         const nameInput = document.createElement('input');
         nameInput.value = p.name || '';
@@ -80,6 +84,12 @@ export async function initTravelPanel() {
         const tagsInput = document.createElement('input');
         tagsInput.value = Array.isArray(p.tags) ? p.tags.join(', ') : '';
         tagsInput.placeholder = 'tags';
+        const ratingInput = document.createElement('input');
+        ratingInput.value = p.Rating || '';
+        ratingInput.placeholder = 'rating';
+        const dateInput = document.createElement('input');
+        dateInput.value = p.Date || '';
+        dateInput.placeholder = 'date';
         const visitedInput = document.createElement('input');
         visitedInput.type = 'checkbox';
         visitedInput.checked = !!p.visited;
@@ -91,7 +101,15 @@ export async function initTravelPanel() {
         cancelBtn.textContent = 'Cancel';
         [saveBtn, cancelBtn].forEach(b => Object.assign(b.style, { background: 'none', border: '1px solid #999', padding: '2px 6px' }));
 
-        form.append(nameInput, tagsInput, visitedInput, saveBtn, cancelBtn);
+        form.append(
+          nameInput,
+          tagsInput,
+          ratingInput,
+          dateInput,
+          visitedInput,
+          saveBtn,
+          cancelBtn
+        );
         td.append(form);
         tr.append(td);
 
@@ -99,6 +117,8 @@ export async function initTravelPanel() {
           ev.preventDefault();
           p.name = nameInput.value.trim();
           p.tags = tagsInput.value.split(',').map(t => t.trim()).filter(Boolean);
+          p.Rating = ratingInput.value.trim();
+          p.Date = dateInput.value.trim();
           p.visited = visitedInput.checked;
           localStorage.setItem('travelData', JSON.stringify(travelData));
           try {
@@ -135,7 +155,7 @@ export async function initTravelPanel() {
       });
       actionsTd.append(delBtn);
 
-      tr.append(nameTd, tagsTd, visitedTd, actionsTd);
+      tr.append(nameTd, tagsTd, ratingTd, dateTd, visitedTd, actionsTd);
       tableBody.append(tr);
       rowMarkerMap.set(tr, m);
 
@@ -161,11 +181,21 @@ export async function initTravelPanel() {
   document.getElementById('addPlaceBtn').addEventListener('click', async () => {
     const name = prompt('Place name:');
     const tags = prompt('Tags (comma separated):');
+    const rating = prompt('Rating:');
+    const date = prompt('Date:');
     const visited = confirm('Visited?');
     const lat = parseFloat(prompt('Latitude:'));
     const lon = parseFloat(prompt('Longitude:'));
     if (!name || Number.isNaN(lat) || Number.isNaN(lon)) return;
-    const place = { name, lat, lon, tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : [], visited };
+    const place = {
+      name,
+      lat,
+      lon,
+      tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+      Rating: rating || '',
+      Date: date || '',
+      visited
+    };
     try {
       const docRef = await db.collection('travel').add(place);
       place.id = docRef.id;


### PR DESCRIPTION
## Summary
- expand travel table columns to include rating and date
- display rating and date values when rendering
- allow editing and adding rating/date values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b044a69b0832781c4263b80c8de2c