### PR TITLE
Toggle tag filters with buttons

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -43,22 +43,22 @@ export async function initTravelPanel() {
     if (!tagFiltersDiv) return;
     tagFiltersDiv.innerHTML = '';
     allTags.forEach(tag => {
-      const label = document.createElement('label');
-      label.style.marginRight = '8px';
-      const cb = document.createElement('input');
-      cb.type = 'checkbox';
-      cb.value = tag;
-      cb.addEventListener('change', () => {
-        if (cb.checked) {
-          selectedTags.push(tag);
-        } else {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = tag;
+      btn.className = 'tag-filter-button';
+      if (selectedTags.includes(tag)) btn.classList.add('active');
+      btn.addEventListener('click', () => {
+        if (selectedTags.includes(tag)) {
           selectedTags = selectedTags.filter(t => t !== tag);
+        } else {
+          selectedTags.push(tag);
         }
+        renderTagFilters();
         renderList(currentSearch);
       });
-      label.append(cb, ' ', tag);
-    tagFiltersDiv.append(label);
-  });
+      tagFiltersDiv.append(btn);
+    });
   };
 
   renderTagFilters();

--- a/style.css
+++ b/style.css
@@ -1024,3 +1024,20 @@ h2 {
   margin-bottom: 20px;
   border-radius: 6px;
 }
+
+/* Tag filter buttons */
+.tag-filter-button {
+  background: #eee;
+  border: 1px solid #ccc;
+  color: #333;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin: 0 6px 6px 0;
+  font-size: 0.9rem;
+}
+.tag-filter-button.active {
+  background: #7aa68c;
+  color: #fff;
+  border-color: #7aa68c;
+}


### PR DESCRIPTION
## Summary
- show travel tags as buttons instead of checkboxes
- style tag filter buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b06652ac88327b0086c8cc423121d