### PR TITLE
Show completed subgoals inline

### DIFF
--- a/js/tasks.js
+++ b/js/tasks.js
@@ -276,9 +276,29 @@ export async function renderChildren(goal, all, container) {
     // Completed items
     const done = children.filter(c => c.completed);
     if (done.length) {
+        const doneSection = document.createElement('div');
+        doneSection.className = 'completed-subgoal-section';
+
+        const hdr = document.createElement('div');
+        hdr.className = 'completed-header';
+        const toggle = document.createElement('span');
+        toggle.textContent = '▶';
+        toggle.style.cursor = 'pointer';
+        hdr.appendChild(toggle);
+        hdr.append(' Completed');
+
         const doneContainer = document.createElement('div');
         doneContainer.className = 'completed-task-list';
-        container.appendChild(doneContainer);
+        doneContainer.style.display = 'none';
+
+        toggle.onclick = () => {
+            const open = doneContainer.style.display === 'block';
+            toggle.textContent = open ? '▶' : '▼';
+            doneContainer.style.display = open ? 'none' : 'block';
+        };
+
+        doneSection.append(hdr, doneContainer);
+        container.appendChild(doneSection);
 
         done.forEach(item => {
             if (item.type === 'task') {

--- a/style.css
+++ b/style.css
@@ -1041,3 +1041,14 @@ h2 {
   color: #fff;
   border-color: #7aa68c;
 }
+
+/* Completed subgoal section */
+.completed-subgoal-section {
+  margin-top: 8px;
+}
+
+.completed-subgoal-section .completed-header {
+  cursor: pointer;
+  font-weight: bold;
+  margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- show completed subgoals in a collapsible section under their parent goal
- minor styling for the new completed subgoal section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d3f4bc4bc83279f2746a23f1a5d35