### PR TITLE
Fix metrics table width on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -965,6 +965,18 @@ h2 {
   overflow-wrap: anywhere;
 }
 
+/* Metrics summary table */
+#genericStatsSummary table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+#genericStatsSummary th,
+#genericStatsSummary td {
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
 #travelPanel table {
   width: 100%;
   table-layout: fixed;


### PR DESCRIPTION
## Summary
- adjust metrics table CSS to prevent overflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6458e91c8327b8a05f0d737398cf