### PR TITLE
Handle Firestore Timestamp in loadDecisions

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -27,7 +27,13 @@ export async function loadDecisions(forceRefresh = false) {
   }
   const snap = await db.collection('decisions').doc(currentUser.uid).get();
   const data = snap.data();
-  decisionsCache = data && Array.isArray(data.items) ? data.items : [];
+  const rawItems = data && Array.isArray(data.items) ? data.items : [];
+  decisionsCache = rawItems.map(it => {
+    if (it && it.hiddenUntil && typeof it.hiddenUntil.toDate === 'function') {
+      return { ...it, hiddenUntil: it.hiddenUntil.toDate().toISOString() };
+    }
+    return it;
+  });
   return decisionsCache;
 }
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -54,6 +54,17 @@ describe('database helpers', () => {
     expect(getMock).toHaveBeenCalled();
   });
 
+  it('converts Timestamp hiddenUntil values to strings', async () => {
+    const future = new Date(Date.now() + 3600 * 1000);
+    const tsObj = { toDate: () => future };
+    getMock.mockResolvedValue({ data: () => ({ items: [{ id: 'g1', text: 't', hiddenUntil: tsObj }] }) });
+    const { loadDecisions } = await import('../js/helpers.js');
+    const result = await loadDecisions(true);
+    expect(typeof result[0].hiddenUntil).toBe('string');
+    const hideUntil = Date.parse(result[0].hiddenUntil) || 0;
+    expect(hideUntil).toBeGreaterThan(Date.now());
+  });
+
   it('saves decisions to Firestore', async () => {
     const items = [{ id: 'a', text: 'b' }];
     const { saveDecisions } = await import('../js/helpers.js');


### PR DESCRIPTION
## Summary
- normalize hiddenUntil values loaded from Firestore
- add regression test for Timestamp handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d666938d4832797b06b128afd1e0b