### PR TITLE
Add HTML escaping tests for linkify

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "purgecss": "^7.0.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "jsdom": "^26.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add jsdom dev dependency to support DOM-based tests
- test HTML escaping for `<script>` injection in `linkify`
- verify escaped output renders safely in a DOM element

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d75b9babc8327b431977c1105fb9a