### PR TITLE
Add supertest server integration test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,7 +12,9 @@ app.use((req, res, next) => {
   next();
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`✅ Serving static files at http://localhost:${PORT}`);
 });
+
+module.exports = server;
 

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0",
+    "fast-xml-parser": "^4.5.3",
     "firebase": "^11.8.1",
-    "firebase-admin": "^13.4.0",
-    "fast-xml-parser": "^4.5.3"
+    "firebase-admin": "^13.4.0"
   },
   "devDependencies": {
     "purgecss": "^7.0.2",
+    "supertest": "^7.1.3",
     "vitest": "^3.2.4"
   }
 }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+
+let server;
+
+beforeAll(async () => {
+  const mod = await import('../backend/server.js');
+  server = mod.default || mod;
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+describe('server', () => {
+  it('serves index.html at GET /', async () => {
+    await request(server)
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(200)
+      .then(res => {
+        expect(res.text).toMatch(/<html/i);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- export the running express server instance
- add new server.test.js using supertest to verify GET `/`
- include `supertest` as a dev dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d75c6f3108327852f12dc022ca033