### PR TITLE
Add recurring event support for calendar

### DIFF
--- a/js/daily.js
+++ b/js/daily.js
@@ -500,15 +500,20 @@ export async function renderDailyTasks(currentUser, db) {
 
     // Add to calendar for weekly tasks
     if (period === 'weekly') {
-      btns.append(makeIconBtn('📅', 'Add to calendar', async () => {
-        const date = prompt('Schedule date (YYYY-MM-DD):', new Date().toISOString().slice(0, 10));
-        if (!date) return;
-        try {
-          await createCalendarEvent(task.text, date.trim());
-        } catch (err) {
-          console.error('Failed to create calendar event', err);
-        }
-      }));
+      btns.append(
+        makeIconBtn('📅', 'Add to calendar', async () => {
+          const date = prompt(
+            'Schedule date (YYYY-MM-DD):',
+            new Date().toISOString().slice(0, 10)
+          );
+          if (!date) return;
+          try {
+            await createCalendarEvent(task.text, date.trim(), 'WEEKLY');
+          } catch (err) {
+            console.error('Failed to create calendar event', err);
+          }
+        })
+      );
     }
 
     // Delete

--- a/js/goals.js
+++ b/js/goals.js
@@ -649,15 +649,22 @@ function attachEditButtons(item, buttonWrap, row) {
 
     // 📅 Schedule button
     const calendarBtn = makeIconBtn('📅', 'Add to calendar', async () => {
-        const date = prompt('Schedule date (YYYY-MM-DD):', item.scheduled || new Date().toISOString().slice(0, 10));
+        const date = prompt(
+            'Schedule date (YYYY-MM-DD):',
+            item.scheduled || new Date().toISOString().slice(0, 10)
+        );
         if (!date) return;
+        const recurrence = prompt(
+            'Repeat how often? (daily/weekly/monthly or blank for none):',
+            ''
+        ) || '';
         const all = await loadDecisions();
         const idx = all.findIndex(d => d.id === item.id);
         if (idx !== -1) {
             all[idx].scheduled = date.trim();
             await saveDecisions(all);
             try {
-                await createCalendarEvent(item.text, date.trim());
+                await createCalendarEvent(item.text, date.trim(), recurrence);
             } catch (err) {
                 console.error('Failed to sync with Google Calendar', err);
             }

--- a/js/googleCalendar.js
+++ b/js/googleCalendar.js
@@ -99,19 +99,30 @@ export function initGoogleCalendar() {
   connectBtn.addEventListener('click', handleAuthClick);
 }
 
-export async function createCalendarEvent(summary, date) {
+export async function createCalendarEvent(summary, date, recurrence = '') {
   if (!window.gapi?.client || !gapi.client.getToken()) {
     console.warn('Google Calendar not connected');
     return;
   }
   try {
+    const resource = {
+      summary,
+      start: { date },
+      end: { date }
+    };
+    if (recurrence) {
+      let rule = recurrence.trim().toUpperCase();
+      if (!rule.startsWith('RRULE:')) {
+        if (!rule.startsWith('FREQ=')) {
+          rule = `FREQ=${rule}`;
+        }
+        rule = `RRULE:${rule}`;
+      }
+      resource.recurrence = [rule];
+    }
     await gapi.client.calendar.events.insert({
       calendarId: 'primary',
-      resource: {
-        summary,
-        start: { date },
-        end: { date }
-      }
+      resource
     });
   } catch (err) {
     console.error('Failed to create calendar event', err);

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -157,8 +157,12 @@ async function saveGoalWizard() {
   await saveDecisions([...updatedItems, ...newItems]);
 
   if (wizardState.calendarDate) {
+    const recur = prompt(
+      'Repeat how often? (daily/weekly/monthly or blank for none):',
+      ''
+    ) || '';
     try {
-      await createCalendarEvent(newGoal.text, wizardState.calendarDate);
+      await createCalendarEvent(newGoal.text, wizardState.calendarDate, recur);
     } catch (err) {
       console.error('Failed to create calendar event', err);
     }

--- a/tests/wizard.test.js
+++ b/tests/wizard.test.js
@@ -28,6 +28,7 @@ beforeEach(() => {
     auth: () => ({ currentUser: { uid: 'user1' } })
   };
   getMock.mockResolvedValue({ data: () => ({ goalOrder: [] }) });
+  global.prompt = vi.fn(() => '');
 });
 
 describe('saveGoalWizard', () => {
@@ -51,6 +52,6 @@ describe('saveGoalWizard', () => {
     });
 
     await saveGoalWizard();
-    expect(createEventMock).toHaveBeenCalledWith('My goal', '2024-01-02');
+    expect(createEventMock).toHaveBeenCalledWith('My goal', '2024-01-02', '');
   });
 });


### PR DESCRIPTION
## Summary
- add recurrence option to calendar events
- prompt for recurrence when scheduling goals and wizard goals
- always create weekly recurrence for weekly tasks
- update tests for new signature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686eb7db0dd08327bb6226cac602d135