### PR TITLE
Fix renderDailyTaskReport decisions load call

### DIFF
--- a/js/report.js
+++ b/js/report.js
@@ -25,7 +25,7 @@ function isDailyTask(item) {
 export async function renderDailyTaskReport(user, db) {
 
     const [decisions, completionsSnap] = await Promise.all([
-        loadDecisions(user, db),
+        loadDecisions(),
         db.collection('taskCompletions').doc(user.uid).get()
     ]);
 


### PR DESCRIPTION
## Summary
- use new no-arg form of `loadDecisions`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ecb702874832786cd6e6731fe2c80