### PR TITLE
Add settings to hide tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
         </div>
         <div class="navbar-right">
           <span id="userEmail" class="user-email"></span>
+          <button type="button" id="settingsBtn">Settings</button>
           <button type="button" id="loginBtn">Sign In</button>
           <button type="button" id="logoutBtn" style="display:none;">Sign Out</button>
         </div>
@@ -209,6 +210,18 @@
         </table>
       </div>
     </div>
+
+    <!-- Settings Modal -->
+    <div id="settingsModal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <h3>Tab Visibility</h3>
+        <div id="settingsTabsList"></div>
+        <div class="modal-actions">
+          <button type="button" id="settingsCancelBtn">Cancel</button>
+          <button type="button" id="settingsSaveBtn">Save</button>
+        </div>
+      </div>
+    </div>
   </section>
 
   <script src="https://apis.google.com/js/api.js"></script>
@@ -216,8 +229,8 @@
   <script type="module" src="js/main.js"></script>
   <script type="module" src="js/lists.js"></script>
   <script type="module" src="js/travel.js"></script>
+  <script type="module" src="js/settings.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
 </body>
-
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ import { initTabs } from './tabs.js';
 import { initButtonStyles } from './buttonStyles.js';
 import { initTabReports } from './tabReports.js';
 import { initGoogleCalendar } from './googleCalendar.js';
+import { initSettings, loadHiddenTabs, applyHiddenTabs } from './settings.js';
 
 window.currentUser = null;
 
@@ -18,6 +19,8 @@ window.addEventListener('DOMContentLoaded', () => {
     loginBtn: document.getElementById('loginBtn'),
     logoutBtn: document.getElementById('logoutBtn'),
     userEmail: document.getElementById('userEmail'),
+    settingsBtn: document.getElementById('settingsBtn'),
+    settingsModal: document.getElementById('settingsModal'),
     signupBtn: document.getElementById('signupBtn'),
     splashLoginBtn: document.getElementById('splashLoginBtn'),
     previewBtn: document.getElementById('previewBtn'),
@@ -58,6 +61,8 @@ window.addEventListener('DOMContentLoaded', () => {
       splash.style.display = 'flex';
       goalsView.style.display = '';
       initTabs(null, db);
+      const hidden = await loadHiddenTabs();
+      applyHiddenTabs(hidden);
       renderGoalsAndSubitems();
       renderDailyTasks(null, db);
       initTabReports(null, db);
@@ -68,6 +73,8 @@ window.addEventListener('DOMContentLoaded', () => {
     goalsView.style.display = '';
 
     initTabs(user, db);
+    const hidden = await loadHiddenTabs();
+    applyHiddenTabs(hidden);
     renderGoalsAndSubitems(user, db);
     renderDailyTasks(user, db);
     initTabReports(user, db);
@@ -87,6 +94,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   initButtonStyles();
   initGoogleCalendar();
+  initSettings(uiRefs);
 });
 
 window.renderDailyTasks = renderDailyTasks;

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,103 @@
+import { auth, db, getCurrentUser } from './auth.js';
+
+const KEY = 'hiddenTabs';
+
+export async function loadHiddenTabs() {
+  const user = getCurrentUser?.();
+  if (!user) {
+    const stored = JSON.parse(localStorage.getItem(KEY) || '[]');
+    return Array.isArray(stored) ? stored : [];
+  }
+  const snap = await db
+    .collection('users').doc(user.uid)
+    .collection('settings').doc(KEY)
+    .get();
+  return snap.exists && Array.isArray(snap.data().tabs) ? snap.data().tabs : [];
+}
+
+export async function saveHiddenTabs(tabs) {
+  const arr = Array.isArray(tabs) ? tabs : [];
+  const user = getCurrentUser?.();
+  if (!user) {
+    localStorage.setItem(KEY, JSON.stringify(arr));
+    return;
+  }
+  await db
+    .collection('users').doc(user.uid)
+    .collection('settings').doc(KEY)
+    .set({ tabs: arr }, { merge: true });
+}
+
+export function applyHiddenTabs(tabs) {
+  const buttons = document.querySelectorAll('.tab-button');
+  let active = document.querySelector('.tab-button.active');
+  buttons.forEach(btn => {
+    const target = btn.dataset.target;
+    if (tabs.includes(target)) {
+      btn.style.display = 'none';
+      const panel = document.getElementById(target);
+      if (panel) panel.style.display = 'none';
+      if (btn === active) active = null;
+    } else {
+      btn.style.display = '';
+    }
+  });
+  if (!active) {
+    const first = Array.from(buttons).find(b => b.style.display !== 'none');
+    if (first) first.click();
+  }
+}
+
+export function initSettings({ settingsBtn, settingsModal }) {
+  if (!settingsBtn || !settingsModal) return;
+
+  const listDiv = settingsModal.querySelector('#settingsTabsList');
+  const panels = ['goalsPanel','calendarPanel','dailyPanel','metricsPanel','listsPanel','travelPanel'];
+
+  if (listDiv.children.length === 0) {
+    panels.forEach(id => {
+      const label = document.createElement('label');
+      label.style.display = 'block';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.value = id;
+      label.appendChild(cb);
+      label.appendChild(document.createTextNode(' ' + id.replace('Panel','')));
+      listDiv.appendChild(label);
+    });
+  }
+
+  settingsBtn.addEventListener('click', async () => {
+    const hidden = await loadHiddenTabs();
+    listDiv.querySelectorAll('input[type=checkbox]').forEach(cb => {
+      cb.checked = !hidden.includes(cb.value);
+    });
+    settingsModal.style.display = 'flex';
+  });
+
+  const saveBtn = settingsModal.querySelector('#settingsSaveBtn');
+  const cancelBtn = settingsModal.querySelector('#settingsCancelBtn');
+
+  saveBtn?.addEventListener('click', async () => {
+    const hidden = [];
+    listDiv.querySelectorAll('input[type=checkbox]').forEach(cb => {
+      if (!cb.checked) hidden.push(cb.value);
+    });
+    await saveHiddenTabs(hidden);
+    applyHiddenTabs(hidden);
+    settingsModal.style.display = 'none';
+  });
+
+  cancelBtn?.addEventListener('click', () => {
+    settingsModal.style.display = 'none';
+  });
+
+  settingsModal.addEventListener('click', e => {
+    if (e.target === settingsModal) settingsModal.style.display = 'none';
+  });
+
+  auth.onAuthStateChanged(async () => {
+    const hidden = await loadHiddenTabs();
+    applyHiddenTabs(hidden);
+  });
+}


### PR DESCRIPTION
## Summary
- add settings UI and script
- load/save hidden tabs per user
- apply hidden tabs on auth events

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ecd8695d083279c48d4691f53f579