### PR TITLE
Improve mobile travel list

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -103,17 +103,24 @@ export async function initTravelPanel() {
       const tr = document.createElement('tr');
       const nameTd = document.createElement('td');
       nameTd.textContent = p.name;
+      nameTd.dataset.label = 'Name';
       const descTd = document.createElement('td');
       descTd.textContent = p.description || '';
+      descTd.dataset.label = 'Description';
       const tagsTd = document.createElement('td');
       tagsTd.textContent = Array.isArray(p.tags) ? p.tags.join(', ') : '';
+      tagsTd.dataset.label = 'Tags';
       const ratingTd = document.createElement('td');
       ratingTd.textContent = p.Rating || '';
+      ratingTd.dataset.label = 'Rating';
       const dateTd = document.createElement('td');
       dateTd.textContent = p.Date || '';
+      dateTd.dataset.label = 'Date';
       const visitedTd = document.createElement('td');
       visitedTd.textContent = p.visited ? '✅' : '';
+      visitedTd.dataset.label = 'Visited';
       const actionsTd = document.createElement('td');
+      actionsTd.dataset.label = 'Actions';
       actionsTd.style.whiteSpace = 'nowrap';
 
       const editBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -1096,6 +1096,40 @@ h2 {
     display: inline-block;
     width: 45%;
   }
+
+  #travelTable,
+  #travelTable thead,
+  #travelTable tbody,
+  #travelTable tr,
+  #travelTable th,
+  #travelTable td {
+    display: block;
+    width: 100%;
+  }
+
+  #travelTable thead {
+    display: none;
+  }
+
+  #travelTable tr {
+    margin-bottom: 12px;
+    border: 1px solid #ccc;
+    padding: 8px;
+    border-radius: 4px;
+  }
+
+  #travelTable td {
+    border: none;
+    padding: 4px 8px;
+    position: relative;
+  }
+
+  #travelTable td::before {
+    content: attr(data-label) ": ";
+    font-weight: bold;
+    display: inline-block;
+    width: 45%;
+  }
 }
 
 #metricPrevDayBtn,


### PR DESCRIPTION
## Summary
- set responsive `travelTable` styles for small screens
- add `data-label` attributes so travel table rows show as list cards on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eceb2446083279d5bd4f7c6086339