### PR TITLE
Add basic error handling to import script

### DIFF
--- a/scripts/importTravelKml.js
+++ b/scripts/importTravelKml.js
@@ -2,11 +2,29 @@ const fs = require('fs');
 const { XMLParser } = require('fast-xml-parser');
 const admin = require('firebase-admin');
 
-const serviceAccount = require('./serviceAccountKey.json');
+const SERVICE_ACCOUNT_PATH = './serviceAccountKey.json';
 
-admin.initializeApp({
-  credential: admin.credential.cert(serviceAccount)
-});
+if (!fs.existsSync(SERVICE_ACCOUNT_PATH)) {
+  console.error(`Missing ${SERVICE_ACCOUNT_PATH}`);
+  process.exit(1);
+}
+
+const serviceAccount = require(SERVICE_ACCOUNT_PATH);
+
+if (process.env.FIRESTORE_EMULATOR_HOST) {
+  console.warn(
+    `FIRESTORE_EMULATOR_HOST is set to ${process.env.FIRESTORE_EMULATOR_HOST}`
+  );
+}
+
+try {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount)
+  });
+} catch (err) {
+  console.error('Failed to initialize Firebase Admin SDK:', err.message);
+  process.exit(1);
+}
 
 const db = admin.firestore();
 
@@ -39,42 +57,61 @@ function parseKml(text) {
 }
 
 async function clearCollection(coll) {
-  const snap = await coll.get();
-  await Promise.all(snap.docs.map(doc => doc.ref.delete()));
+  try {
+    const snap = await coll.get();
+    await Promise.all(snap.docs.map(doc => doc.ref.delete()));
+  } catch (err) {
+    throw new Error(`Failed to clear collection ${coll.path}: ${err.message}`);
+  }
 }
 
 async function importPlaces(places) {
   const batchSize = 400;
   let batch = db.batch();
   let count = 0;
-  for (const place of places) {
-    const ref = db
-      .collection('users')
-      .doc(DEFAULT_USER_ID)
-      .collection('travel')
-      .doc();
-    batch.set(ref, place);
-    count++;
-    if (count % batchSize === 0) {
-      await batch.commit();
-      batch = db.batch();
+  try {
+    for (const place of places) {
+      const ref = db
+        .collection('users')
+        .doc(DEFAULT_USER_ID)
+        .collection('travel')
+        .doc();
+      batch.set(ref, place);
+      count++;
+      if (count % batchSize === 0) {
+        await batch.commit();
+        batch = db.batch();
+      }
     }
-  }
-  if (count % batchSize !== 0) {
-    await batch.commit();
+    if (count % batchSize !== 0) {
+      await batch.commit();
+    }
+  } catch (err) {
+    throw new Error(`Failed to import places: ${err.message}`);
   }
 }
 
 async function main() {
-  const text = fs.readFileSync('assets/travel/doc.kml', 'utf8');
+  const filePath = 'assets/travel/doc.kml';
+  let text;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    console.error(`Unable to read ${filePath}:`, err.message);
+    process.exit(1);
+  }
+
   const places = parseKml(text);
 
-  await clearCollection(
-    db.collection('users').doc(DEFAULT_USER_ID).collection('travel')
-  );
+  const collection = db
+    .collection('users')
+    .doc(DEFAULT_USER_ID)
+    .collection('travel');
+
+  await clearCollection(collection);
   await importPlaces(places);
 
-  console.log(`Imported ${places.length} places`);
+  console.log(`Imported ${places.length} places into ${collection.path}`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- warn when running against emulator
- handle missing credentials
- show clearer error messages during import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f01ee970083278d13b8a004bb4c43