### PR TITLE
Fix list tab wrapping on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -965,6 +965,10 @@ h2 {
     overflow-x: auto;
   }
 
+  #listTabs {
+    flex-wrap: wrap;
+  }
+
   /* tables inside report panels and stats summary should scroll */
   .report-panel {
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- make list tab container wrap when viewport is narrow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0702cab08327a08bd30a5c633484