### PR TITLE
Remove calendar full column

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,9 +131,6 @@
         </div>
         <p>No events today.</p>
       </div>
-      <div class="full-column">
-        <div id="calendarReport" class="report-panel"></div>
-      </div>
     </div>
 
     <!-- DAILY PANEL -->


### PR DESCRIPTION
## Summary
- remove unused full-column container from calendar panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f0c237ff083279890981278d2f7c7