### PR TITLE
Fix daily report layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -827,6 +827,16 @@ h2 {
   flex: 1 1 100%;
 }
 
+/* Layout for daily panel: allow tasks columns side-by-side with report below */
+#dailyPanel.main-layout {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+#dailyPanel .full-column {
+  flex: 1 1 100%;
+}
+
 /* Minimalist list-selector tabs */
 #listTabs {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure dailyPanel uses wrapping flex layout so the daily report appears beneath task lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f100149948327b4270820017959a5