### PR TITLE
Reload travel data after sign‑in

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -10,6 +10,11 @@ function storageKey() {
 auth.onAuthStateChanged(() => {
   mapInitialized = false;
   travelData = [];
+  // Reload travel data for the newly authenticated user.
+  // initTravelPanel safely exits if DOM is not ready or already initialized.
+  initTravelPanel().catch(err =>
+    console.error('Failed to reload travel data after auth change', err)
+  );
 });
 
 let mapInitialized = false;


### PR DESCRIPTION
## Summary
- refresh the Travel panel whenever the authentication state changes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0c6d04308327b2c35fac0a776736