### PR TITLE
Fix firestore rules for travel collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,45 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // 1) User settings under /users/{uid}/settings/{docId}
+    match /users/{userId}/settings/{settingDocId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 2) Daily stats under /users/{uid}/dailyStats/{statDocId}
+    match /users/{userId}/dailyStats/{statDocId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 3) Task completions at /taskCompletions/{uid}
+    match /taskCompletions/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 4) Goals ordering at /decisions/{uid}
+    match /decisions/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 5) Lists storage at /lists/{uid}
+    match /lists/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 6) Daily notes at /dailyNotes/{uid}/notes/{noteId}
+    match /dailyNotes/{userId}/notes/{noteId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // 7) Travel data at /users/{uid}/travel/{placeId}
+    match /users/{userId}/travel/{placeId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Everything else locked down
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add firestore.rules file to define security rules
- allow authenticated users to read/write their own travel data

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f15c3c5b08327b2709727ce7a04d7