### PR TITLE
Fix list overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1015,7 +1015,7 @@ h2 {
 
 @media (max-width: 600px) {
   #listsContainer {
-    overflow-x: auto;
+    overflow-x: hidden;
   }
 
   #listTabs {
@@ -1185,17 +1185,17 @@ h2 {
   margin-left: 20px;
 }
 
-/* Mobile: tighten vertical spacing but keep some horizontal padding */
+/* Mobile: remove outer padding to avoid horizontal scrolling */
 @media (max-width: 600px) {
   #goalsView {
-    margin: 0 auto;
-    padding: 0 12px;
+    margin: 0;
+    padding: 0;
   }
 
   #goalsView .left-column,
   #goalsView .right-column,
   #goalsView .full-column {
-    padding: 0 12px;
+    padding: 0;
   }
 
   .navbar {


### PR DESCRIPTION
## Summary
- stop lists from horizontally scrolling on small screens
- remove outer padding to keep lists flush with the edges

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f17fd97348327a6ded4ece7a9b050