### PR TITLE
Fix travel map sizing

### DIFF
--- a/js/travel.js
+++ b/js/travel.js
@@ -29,7 +29,12 @@ let selectedTags = [];
 
 export async function initTravelPanel() {
   const panel = document.getElementById('travelPanel');
-  if (!panel || mapInitialized) return;
+  if (!panel) return;
+  if (mapInitialized) {
+    // panel is being re-shown; resize the map to fill its container
+    map.invalidateSize();
+    return;
+  }
   mapInitialized = true;
 
   const mapEl = document.getElementById('travelMap');
@@ -49,6 +54,9 @@ export async function initTravelPanel() {
     attribution: '© OpenStreetMap contributors',
     noWrap: true
   }).addTo(map);
+
+  // Ensure map fills its container once it is visible
+  setTimeout(() => map.invalidateSize(), 0);
 
   const user = getCurrentUser?.();
   try {


### PR DESCRIPTION
## Summary
- keep Leaflet map full size when the Travel tab is opened
- update `initTravelPanel` to resize the map when the panel is shown again

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f189eae448327924546b7dcb101ff