### PR TITLE
Enable inline task editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An app for tracking goals and tasks.
 
 - New goal wizard creates subgoals instead of subtasks.
 - Goals can now be scheduled directly on your calendar during creation.
+- Tasks can be edited inline without pop-up prompts.
 
 👉 **Live App:** [https://davidanderson3.github.io/goal-oriented/](https://davidanderson3.github.io/goal-oriented/)
 

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -41,26 +41,50 @@ export function attachTaskButtons(item, row, listContainer, allDecisions) {
         }
     });
 
-    // Edit
+    // Edit inline
+    let editing = false;
     const editBtn = makeIconBtn('✏️', 'Edit task', async () => {
-        const newText = prompt('Edit task:', item.text);
-        if (newText === null) return;
-        const newNotes = prompt('Task notes:', item.notes || '');
-        const idx = allDecisions.findIndex(d => d.id === item.id);
-        if (idx === -1) return;
-        if (typeof newText === 'string') allDecisions[idx].text = newText.trim();
-        if (newNotes !== null) allDecisions[idx].notes = newNotes.trim();
-        await saveDecisions(allDecisions);
         const middle = row.querySelector('.middle-group');
-        if (middle) {
+        if (!middle) return;
+
+        if (!editing) {
+            editing = true;
+            editBtn.textContent = '💾';
+
+            const textInput = document.createElement('input');
+            textInput.value = item.text;
+            textInput.style.width = '100%';
+
+            const notesInput = document.createElement('textarea');
+            notesInput.value = item.notes || '';
+            notesInput.rows = 2;
+            notesInput.style.width = '100%';
+            notesInput.style.marginTop = '4px';
+
+            middle.innerHTML = '';
+            middle.appendChild(textInput);
+            middle.appendChild(notesInput);
+        } else {
+            editing = false;
+            editBtn.textContent = '✏️';
+
+            const newText = middle.querySelector('input')?.value.trim();
+            const newNotes = middle.querySelector('textarea')?.value.trim();
+            const idx = allDecisions.findIndex(d => d.id === item.id);
+            if (idx !== -1) {
+                allDecisions[idx].text = newText;
+                allDecisions[idx].notes = newNotes;
+                await saveDecisions(allDecisions);
+            }
+
             middle.innerHTML = '';
             const tDiv = document.createElement('div');
-            tDiv.innerHTML = linkify(allDecisions[idx].text);
+            tDiv.innerHTML = linkify(newText);
             middle.appendChild(tDiv);
-            if (allDecisions[idx].notes) {
+            if (newNotes) {
                 const nDiv = document.createElement('div');
                 nDiv.className = 'note-text';
-                nDiv.innerHTML = linkify(allDecisions[idx].notes);
+                nDiv.innerHTML = linkify(newNotes);
                 middle.appendChild(nDiv);
             }
         }


### PR DESCRIPTION
## Summary
- allow editing tasks directly inside the task row instead of prompts
- document the new inline editing ability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f1ab654ac83278aefbbc35c6ebdd1