### PR TITLE
Fix tag button styling

### DIFF
--- a/js/buttonStyles.js
+++ b/js/buttonStyles.js
@@ -26,8 +26,9 @@ function styleButton(btn) {
     return;
   }
 
-  // 1️⃣ Skip icon-only buttons
+  // 1️⃣ Skip icon-only buttons or tag-filter buttons
   if (isIconButton(btn)) return;
+  if (btn.classList.contains('tag-filter-button')) return;
 
   // 2️⃣ Style everything else
   btn.style.backgroundColor = randomDarkColor();


### PR DESCRIPTION
## Summary
- exclude `.tag-filter-button` elements from random styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f1ac8ad54832788c1bb05baa19a8e