### PR TITLE
Fix list actions spacing

### DIFF
--- a/js/lists.js
+++ b/js/lists.js
@@ -362,8 +362,7 @@ async function initListsPanel() {
       actionCell.style.border = '1px solid #ccc';
       actionCell.style.padding = '8px';
       actionCell.dataset.label = 'Actions';
-      actionCell.style.display = 'flex';
-      actionCell.style.gap = '0.5rem';
+      actionCell.style.whiteSpace = 'nowrap';
 
       // Up button
       const upBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- compact the list actions column to keep icons closer together

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686f265cbaac83278bf0dc459c80e8dd