### PR TITLE
Improve add item button contrast

### DIFF
--- a/js/lists.js
+++ b/js/lists.js
@@ -623,7 +623,8 @@ async function initListsPanel() {
 
     const addBtn = document.createElement('button');
     addBtn.type = 'button';
-    addBtn.textContent = '➕ Add';
+    addBtn.className = 'add-item-btn';
+    addBtn.innerHTML = '<span class="plus-icon">+</span> Add';
     Object.assign(addBtn.style, {
       padding: '.25rem .75rem', fontSize: '.9rem', cursor: 'pointer', marginTop: '.5rem'
     });

--- a/style.css
+++ b/style.css
@@ -1197,6 +1197,12 @@ h2 {
   background: #eee;
 }
 
+/* Style the plus icon on the add-item button */
+.add-item-btn .plus-icon {
+  color: #fff;
+  margin-right: 4px;
+}
+
 /* Completed subgoal section */
 .completed-subgoal-section {
   margin-top: 8px;


### PR DESCRIPTION
## Summary
- make list item add button use a styled `+` icon so the plus displays in white

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ff181b3e08327aabaa3161b915740