### PR TITLE
Improve mobile navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <nav class="navbar">
       <div class="container navbar-inner">
         <div class="navbar-left">Goal Oriented</div>
+        <button class="menu-toggle" aria-label="Menu">&#9776;</button>
         <div class="tabs">
           <button class="tab-button active" data-target="goalsPanel">Goals</button>
           <button class="tab-button" data-target="calendarPanel">Calendar</button>

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,7 @@ import { initButtonStyles } from './buttonStyles.js';
 import { initTabReports } from './tabReports.js';
 import { initGoogleCalendar } from './googleCalendar.js';
 import { loadHiddenTabs, applyHiddenTabs } from './settings.js';
+import { initMobileNavbar } from './navbar.js';
 
 window.currentUser = null;
 
@@ -100,6 +101,7 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   initButtonStyles();
+  initMobileNavbar();
   initGoogleCalendar();
 });
 

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,10 @@
+export function initMobileNavbar() {
+  const navbars = document.querySelectorAll('.navbar');
+  navbars.forEach(nav => {
+    const toggle = nav.querySelector('.menu-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('expanded');
+    });
+  });
+}

--- a/js/settingsPage.js
+++ b/js/settingsPage.js
@@ -1,5 +1,7 @@
 import { initSettingsPage } from './settings.js';
+import { initMobileNavbar } from './navbar.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   initSettingsPage();
+  initMobileNavbar();
 });

--- a/report.html
+++ b/report.html
@@ -15,6 +15,7 @@
     <nav class="navbar">
         <div class="container navbar-inner">
             <div class="navbar-left">Goal Oriented</div>
+            <button class="menu-toggle" aria-label="Menu">&#9776;</button>
             <div class="navbar-right">
                 <a href="settings.html" id="settingsBtn" class="icon-btn"><img src="assets/gear.svg" alt="Settings" /></a>
                 <button type="button" id="loginBtn">Sign In</button>

--- a/settings.html
+++ b/settings.html
@@ -10,6 +10,7 @@
   <nav class="navbar">
     <div class="container navbar-inner">
       <div class="navbar-left"><a href="index.html">Goal Oriented</a></div>
+      <button class="menu-toggle" aria-label="Menu">&#9776;</button>
       <div class="navbar-right">
         <span id="settingsEmail" class="user-email"></span>
         <button type="button" id="logoutBtn" class="icon-btn" style="display:none;"><img src="assets/sign-out.svg" alt="Sign Out" /></button>

--- a/style.css
+++ b/style.css
@@ -71,6 +71,10 @@ body {
   font-size: 1.3em;
 }
 
+.menu-toggle {
+  display: none;
+}
+
 .navbar-left a {
   text-decoration: none;
   color: inherit;
@@ -112,42 +116,31 @@ body {
 }
 
 @media (max-width: 600px) {
+  .menu-toggle {
+    display: block;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+  }
+
   .navbar-inner {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .navbar .tabs,
+  .navbar .navbar-right {
+    display: none;
     flex-direction: column;
-    align-items: center;
-  }
-
-  .navbar-left {
+    width: 100%;
     text-align: center;
-    width: 100%;
+    margin: 0;
   }
 
-  #goalsView .navbar .tabs {
-    width: 100%;
+  .navbar.expanded .tabs,
+  .navbar.expanded .navbar-right {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 2px;
-    margin: 4px 0 0 0;
-  }
-
-  #goalsView .navbar .tabs button {
-    flex: 1 1 auto;
-    padding: 4px 6px;
-    /* slightly tighter vertical spacing */
-    font-size: 0.9rem;
-    line-height: 1.1;
-    /* keep text compact without squeezing */
-  }
-
-  .navbar-right {
-    width: 100%;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .main-layout {
-    padding: 0 4px;
   }
 }
 
@@ -517,13 +510,10 @@ button:hover {
   }
 
   .navbar {
-    flex-direction: column;
-    gap: 8px;
-    align-items: flex-start;
+    align-items: center;
   }
 
   .navbar-right {
-    display: flex;
     flex-wrap: wrap;
     gap: 8px;
   }


### PR DESCRIPTION
## Summary
- add a new `navbar.js` for toggling mobile menus
- call mobile navbar initializer from `main.js` and `settingsPage.js`
- insert menu toggle buttons in navbar markup
- style navbar for collapsible layout on small screens

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ff37f947c8327b23a4007d6e5c5e2