### PR TITLE
Improve subgoal completion

### DIFF
--- a/js/goals.js
+++ b/js/goals.js
@@ -63,7 +63,11 @@ export function createGoalRow(goal, options = {}) {
             await saveDecisions(items);
 
             if (options.stayPut) {
-                await renderGoalsAndSubitems();
+                if (typeof options.onToggle === 'function') {
+                    await options.onToggle(checkbox.checked, items);
+                } else {
+                    await renderGoalsAndSubitems();
+                }
                 return;
             }
 

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -199,7 +199,11 @@ export async function renderChildren(goal, all, container) {
         wrap.className = 'decision goal-card indent-1';
         wrap.dataset.goalId = g.id;
 
-        const row = createGoalRow(g, { hideScheduled: true, stayPut: true });
+        const row = createGoalRow(g, {
+            hideScheduled: true,
+            stayPut: true,
+            onToggle: () => renderChildren(goal, all, container)
+        });
         wrap.appendChild(row);
 
         const childContainer = document.createElement('div');
@@ -397,7 +401,11 @@ export async function renderChildren(goal, all, container) {
                 wrap.dataset.goalId = item.id;
                 wrap.setAttribute('draggable', 'false');
 
-                const row = createGoalRow(item, { hideScheduled: true, stayPut: true });
+                const row = createGoalRow(item, {
+                    hideScheduled: true,
+                    stayPut: true,
+                    onToggle: () => renderChildren(goal, all, container)
+                });
                 Object.assign(row.style, {
                     padding: '4px 8px',
                     fontSize: '0.85em',


### PR DESCRIPTION
## Summary
- avoid full-page refresh when toggling a subgoal
- rerender only the parent goal's children when subgoals change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffb591f5c83278b336d7a2f6b0dc1