### PR TITLE
Fix sliding mobile navbar layout

### DIFF
--- a/js/navbar.js
+++ b/js/navbar.js
@@ -15,5 +15,9 @@ export function initMobileNavbar() {
     });
 
     overlay.addEventListener('click', closeMenu);
+
+    nav.querySelectorAll('.mobile-menu a, .mobile-menu button.tab-button').forEach(el => {
+      el.addEventListener('click', closeMenu);
+    });
   });
 }

--- a/style.css
+++ b/style.css
@@ -151,6 +151,34 @@ body {
     transform: translateX(0);
   }
 
+  .mobile-menu .tabs {
+    flex: none;
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+  }
+
+  .mobile-menu .tabs .tab-button {
+    width: 100%;
+    text-align: left;
+    padding: 12px 16px;
+    border: none;
+    border-bottom: 1px solid #eee;
+  }
+
+  .mobile-menu .navbar-right {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .mobile-menu .navbar-right button {
+    margin-left: 0;
+    width: 100%;
+  }
+
   .nav-overlay {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- make mobile menu buttons vertical and full width
- close the menu when clicking a tab or link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687003c65c7083279e555daa2107e50a