### PR TITLE
Implement goal focus mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,10 @@
     <!-- TABS CONTENT PANELS -->
     <div id="goalsPanel" class="main-layout">
       <div class="full-column">
-        <h2 id="goalsHeader">Goals</h2>
+        <div id="goalsHeaderRow">
+          <h2 id="goalsHeader">Goals</h2>
+          <button id="focusBtn">Focus</button>
+        </div>
 
         <div id="goalList" class="decision-container"></div>
         <div class="wizard-panel">

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 import { loadDecisions, saveDecisions, generateId } from './helpers.js';
 import { renderDailyTasks } from './daily.js';
-import { renderGoalsAndSubitems } from './goals.js';
+import { renderGoalsAndSubitems, initFocusButton } from './goals.js';
 import { initAuth } from './auth.js';
 import { db } from './auth.js';
 import { initWizard } from './wizard.js';
@@ -29,7 +29,8 @@ window.addEventListener('DOMContentLoaded', () => {
     wizardStep: document.getElementById('wizardStep'),
     nextBtn: document.getElementById('wizardNextBtn'),
     backBtn: document.getElementById('wizardBackBtn'),
-    cancelBtn: document.getElementById('wizardCancelBtn')
+    cancelBtn: document.getElementById('wizardCancelBtn'),
+    focusBtn: document.getElementById('focusBtn')
   };
 
   const splash = document.getElementById('splash');
@@ -98,6 +99,8 @@ window.addEventListener('DOMContentLoaded', () => {
   if (uiRefs.wizardContainer && uiRefs.wizardStep) {
     initWizard(uiRefs);
   }
+
+  initFocusButton();
 
   initButtonStyles();
   initGoogleCalendar();

--- a/style.css
+++ b/style.css
@@ -882,6 +882,12 @@ h2 {
   /* 0.5em top & bottom, 0 left & right */
 }
 
+#goalsHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 /* base look */
 .postpone-option {
   display: block;


### PR DESCRIPTION
## Summary
- add a `Focus` button in the goals panel
- style header row in CSS
- implement `focusOnGoal` and `initFocusButton` helpers
- initialise focus feature from main startup logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870131138d48327ae3ccf78af6064de