### PR TITLE
Improve mobile navigation tabs

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,6 +118,7 @@ body {
   gap: 8px;
   padding: 0 8px;
   scrollbar-width: thin;
+  touch-action: pan-x;
 }
 
 .scroll-tabs::-webkit-scrollbar {
@@ -1291,6 +1292,30 @@ h2 {
   .navbar-right {
     justify-content: center;
     align-items: center;
+  }
+
+  .navbar-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .navbar .tabs {
+    order: 2;
+    width: 100%;
+  }
+
+  .navbar-right {
+    order: 3;
+    width: 100%;
+    margin-top: 4px;
+  }
+
+  .navbar .tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .navbar .tabs {
+    scrollbar-width: none;
   }
 
     .main-layout {


### PR DESCRIPTION
## Summary
- allow horizontal finger panning on tab list
- stack navbar items vertically on small screens

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687013b88dd083279f17f238f9bf1478