### PR TITLE
Mobile navbar cleanup

### DIFF
--- a/assets/sign-out.svg
+++ b/assets/sign-out.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-right" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
   <path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"/>
 </svg>

--- a/style.css
+++ b/style.css
@@ -1295,14 +1295,11 @@ h2 {
     align-items: center;
   }
 
-  .navbar-right {
-    justify-content: center;
-    align-items: center;
-  }
 
   .navbar-inner {
     flex-direction: column;
     align-items: flex-start;
+    position: relative;
   }
 
   .navbar .tabs {
@@ -1311,9 +1308,15 @@ h2 {
   }
 
   .navbar-right {
-    order: 3;
-    width: 100%;
-    margin-top: 4px;
+    position: absolute;
+    right: 24px;
+    top: 5px;
+    order: 1;
+    width: auto;
+    margin-top: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
 
   .navbar .tabs::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- reposition auth controls on small screens
- remove outline from sign out icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687019a0a73c8327b262808e6004562a