### PR TITLE
Update travel panel defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,9 @@
         <ul id="placeResults" class="search-results"></ul>
         <div id="travelMap" style="height:360px; max-width:100%; border:1px solid #ccc;"></div>
         <input id="travelSearch" type="text" placeholder="Filter list..." style="margin:8px 0;max-width:260px;">
-        <button id="sortByDistanceBtn" type="button" style="margin-left:8px">Sort by Distance</button>
+        <label style="margin-left:8px; white-space:nowrap;">
+          <input id="showVisitedToggle" type="checkbox"> Include visited
+        </label>
         <div id="travelTagFilters" style="margin:8px 0;"></div>
         <table id="travelTable">
           <thead>


### PR DESCRIPTION
## Summary
- default sort of travel table by distance based on geolocation
- remove manual sort button and filter visited items by default
- add a checkbox to show visited places

## Testing
- `npx vitest run` *(fails: `npm ERR! canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_68701d6249a88327a6471b516c0b7ad5