### PR TITLE
Hide tab flash on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <nav class="navbar">
       <div class="container navbar-inner">
         <div class="navbar-left">Goal Oriented</div>
-        <div class="tabs scroll-tabs">
+        <div class="tabs scroll-tabs" id="tabsContainer" style="visibility:hidden;">
           <button class="tab-button active" data-target="goalsPanel">Goals</button>
           <button class="tab-button" data-target="calendarPanel">Calendar</button>
           <button class="tab-button" data-target="dailyPanel">Recurring</button>
@@ -86,7 +86,7 @@
         </div>
         <div class="navbar-right">
           <a href="settings.html" id="settingsBtn" class="icon-btn"><img src="assets/gear.svg" alt="Settings" /></a>
-          <button type="button" id="loginBtn">Sign In</button>
+          <button type="button" id="loginBtn" style="display:none;">Sign In</button>
           <button type="button" id="logoutBtn" class="icon-btn" style="display:none;"><img src="assets/sign-out.svg" alt="Sign Out" /></button>
         </div>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,8 @@ window.addEventListener('DOMContentLoaded', () => {
       initTabs(null, db);
       const hidden = await loadHiddenTabs();
       applyHiddenTabs(hidden);
+      const tabsEl = document.getElementById('tabsContainer');
+      if (tabsEl) tabsEl.style.visibility = 'visible';
       renderGoalsAndSubitems();
       renderDailyTasks(null, db);
       initTabReports(null, db);
@@ -76,6 +78,8 @@ window.addEventListener('DOMContentLoaded', () => {
     initTabs(user, db);
     const hidden = await loadHiddenTabs();
     applyHiddenTabs(hidden);
+    const tabsEl = document.getElementById('tabsContainer');
+    if (tabsEl) tabsEl.style.visibility = 'visible';
     renderGoalsAndSubitems(user, db);
     renderDailyTasks(user, db);
     initTabReports(user, db);


### PR DESCRIPTION
## Summary
- hide tabs container until settings load
- hide login button by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870206f14a083279143d4e74e3e346b