### PR TITLE
Fix mobile navbar alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,6 +101,9 @@ body {
   padding: 0;
   margin-left: 10px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .navbar-right .icon-btn img {
@@ -1292,25 +1295,26 @@ h2 {
 
 
   .navbar-inner {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
     position: relative;
   }
 
+  .navbar-left {
+    flex: 0 0 auto;
+  }
+
   .navbar .tabs {
-    order: 2;
-    width: 100%;
+    flex: 1 1 auto;
+    margin: 0;
+    padding: 0 8px;
   }
 
   .navbar-right {
-    position: absolute;
-    right: 24px;
-    top: 5px;
-    order: 1;
-    width: auto;
-    margin-top: 0;
+    position: static;
+    margin-left: auto;
     display: flex;
-    flex-direction: row;
     align-items: center;
   }
 


### PR DESCRIPTION
## Summary
- ensure mobile navbar icons are centered
- make tabs fill available width and keep icons on the right

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870268cf8fc832789832b9655db8023