### PR TITLE
Fix mobile margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -1277,7 +1277,7 @@ h2 {
 @media (max-width: 600px) {
   #goalsView {
     margin: 0;
-    padding: 0 4px;
+    padding: 0;
   }
 
   #goalsView .left-column,
@@ -1325,6 +1325,6 @@ h2 {
   }
 
   .main-layout {
-    padding: 0 4px;
+    padding: 0;
   }
 }


### PR DESCRIPTION
## Summary
- remove stray 4px padding for main container on mobile

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707da5c4588327b7489f5603397569