### PR TITLE
Fix travel view width on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -864,6 +864,7 @@ button:hover {
 #goalsView .full-column {
   background: rgba(255, 255, 255, 0.85);
   width: 100%;
+  box-sizing: border-box;
   padding: 20px;
   border: 1px solid #d0decf;
   border-top: none;


### PR DESCRIPTION
## Summary
- fix overflow in travel panel layout on mobile by using border-box sizing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68707de387648327aaecafc34eb83d1e