### PR TITLE
Fix unsaved postponements for anonymous users

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -39,7 +39,11 @@ export async function loadDecisions(forceRefresh = false) {
 
 export async function saveDecisions(items) {
   const currentUser = getCurrentUser();
-  if (!currentUser || !Array.isArray(items)) return;
+  if (!currentUser) {
+    alert('⚠️ Please sign in to save your changes.');
+    return;
+  }
+  if (!Array.isArray(items)) return;
   // ensure at least one valid decision exists
   if (!items.some(i => i.id && i.text)) {
     console.warn('⚠️ Refusing to save empty or invalid decisions');

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -123,6 +123,15 @@ describe('database helpers', () => {
     expect(alertSpy).toHaveBeenCalled();
   });
 
+  it('alerts when not signed in', async () => {
+    vi.doMock('../js/auth.js', () => ({ getCurrentUser: () => null, db: {} }));
+    const alertSpy = vi.fn();
+    global.alert = alertSpy;
+    const { saveDecisions } = await import('../js/helpers.js');
+    await saveDecisions([{ id: 'x', text: 'y' }]);
+    expect(alertSpy).toHaveBeenCalled();
+  });
+
   it('saves lists for anonymous users to localStorage', async () => {
     // Remock getCurrentUser to return null
     vi.doMock('../js/auth.js', () => ({ getCurrentUser: () => null, db: {} }));


### PR DESCRIPTION
## Summary
- prompt sign-in when saving goals without a user
- test that anonymous saves trigger alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68707e072b2c8327b05328a949f14c24